### PR TITLE
Adjustments to attributions of variables in DBlock and RBlock

### DIFF
--- a/src/skagent/model.py
+++ b/src/skagent/model.py
@@ -304,6 +304,31 @@ class DBlock(Block):
 
         return [sym for sym in dyn if isinstance(dyn[sym], Control)]
 
+    def get_attributions(self):
+        """
+        Return the agent assignments of variables as a dict of
+        the form {"agent1" : ["var1", "var2", ... ], "agent2" : ["var3", "var4", ...]}
+        """
+        attributions = {}
+        dyn = self.get_dynamics()
+
+        for sym in self.get_controls():
+            if dyn[sym].agent is not None:
+                agent_name = dyn[sym].agent
+
+                agent_attr = attributions.get(agent_name, [])
+                agent_attr.append(sym)
+                attributions[agent_name] = agent_attr
+
+        for sym in self.reward:
+            agent_name = self.reward[sym]
+
+            agent_attr = attributions.get(agent_name, [])
+            agent_attr.append(sym)
+            attributions[agent_name] = agent_attr
+
+        return attributions
+
     def transition(self, pre, dr, screen=False):
         """
         Computes the state variables following pre-given states,

--- a/src/skagent/model.py
+++ b/src/skagent/model.py
@@ -36,14 +36,21 @@ class Control:
     iset : list of str
         The labels of the variables that are in the information set of this control.
 
+    lower_bound : function
+        An 'equation function' which evaluates to the lower bound of the control variable.
+
     upper_bound : function
         An 'equation function' which evaluates to the upper bound of the control variable.
+
+    agent : str
+        A label identifying the agent role to which this control is attributed.
     """
 
-    def __init__(self, iset, lower_bound=None, upper_bound=None):
+    def __init__(self, iset, lower_bound=None, upper_bound=None, agent=None):
         self.iset = iset
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
+        self.agent = agent
 
 
 def discretized_shock_dstn(shocks, disc_params):

--- a/src/skagent/models/consumer.py
+++ b/src/skagent/models/consumer.py
@@ -31,11 +31,12 @@ consumption_block = DBlock(
             "b": lambda k, R: k * R,
             "y": lambda p, theta: p * theta,
             "m": lambda b, y: b + y,
-            "c": Control(["m"], upper_bound=lambda m: m),
+            "c": Control(["m"], upper_bound=lambda m: m, agent="consumer"),
             "p": lambda PermGroFac, p: PermGroFac * p,
             "a": lambda m, c: m - c,
+            "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),
         },
-        "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+        "reward": {"u": "consumer"},
     }
 )
 
@@ -49,10 +50,11 @@ consumption_block_normalized = DBlock(
         "dynamics": {
             "b": lambda k, R, PermGroFac: k * R / PermGroFac,
             "m": lambda b, theta: b + theta,
-            "c": Control(["m"], upper_bound=lambda m: m),
+            "c": Control(["m"], upper_bound=lambda m: m, agent="consumer"),
             "a": "m - c",
+            "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),
         },
-        "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+        "reward": {"u": "consumer"},
     }
 )
 

--- a/src/skagent/models/consumer.yaml
+++ b/src/skagent/models/consumer.yaml
@@ -27,10 +27,12 @@ blocks:
       m: b + theta
       c: !Control
         info: m
+        agent: consumer
       a: m - c
-
-    reward:
       u: c ** (1 - CRRA) / (1 - CRRA)
+    reward:
+      u: consumer
+
   - &portfolio_choice
     name: portfolio choice
     shocks:

--- a/src/skagent/models/fisher.py
+++ b/src/skagent/models/fisher.py
@@ -20,7 +20,8 @@ block = DBlock(
             "m": lambda Rfree, a, y: Rfree * a + y,
             "c": Control(["m"]),
             "a": lambda m, c: m - c,
+            "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),
         },
-        "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+        "reward": {"u": "consumer"},
     }
 )

--- a/src/skagent/models/perfect_foresight.py
+++ b/src/skagent/models/perfect_foresight.py
@@ -22,7 +22,8 @@ block = DBlock(
             "c": Control(["m"], upper_bound=lambda m: m),
             "p": lambda PermGroFac, p: PermGroFac * p,
             "a": lambda m, c: m - c,
+            "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),
         },
-        "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+        "reward": {"u": "consumer"},
     }
 )

--- a/src/skagent/models/perfect_foresight.py
+++ b/src/skagent/models/perfect_foresight.py
@@ -19,7 +19,7 @@ block = DBlock(
         "dynamics": {
             "y": lambda p: p,
             "m": lambda Rfree, a, y: Rfree * a + y,
-            "c": Control(["m"], upper_bound=lambda m: m),
+            "c": Control(["m"], upper_bound=lambda m: m, agent="consumer"),
             "p": lambda PermGroFac, p: PermGroFac * p,
             "a": lambda m, c: m - c,
             "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),

--- a/src/skagent/models/perfect_foresight_normalized.py
+++ b/src/skagent/models/perfect_foresight_normalized.py
@@ -22,7 +22,8 @@ block = DBlock(
             "m_nrm": lambda b_nrm: b_nrm + 1,
             "c_nrm": Control(["m_nrm"], upper_bound=lambda m_nrm: m_nrm),
             "a_nrm": lambda m_nrm, c_nrm: m_nrm - c_nrm,
+            "u": lambda c_nrm, CRRA: c_nrm ** (1 - CRRA) / (1 - CRRA),
         },
-        "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+        "reward": {"u": "consumer"},
     }
 )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,11 +16,12 @@ test_block_A_data = {
     "dynamics": {
         "y": lambda p: p,
         "m": lambda Rfree, a, y: Rfree * a + y,
-        "c": Control(["m"]),
+        "c": Control(["m"], agent="consumer"),
         "p": lambda PermGroFac, p: PermGroFac * p,
         "a": lambda m, c: m - c,
+        "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),
     },
-    "reward": {"u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA)},
+    "reward": {"u": "consumer"},
 }
 
 test_block_B_data = {"name": "test block B", "shocks": {"SB": Bernoulli(p=0.1)}}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -89,6 +89,15 @@ class test_DBlock(unittest.TestCase):
 
         av({"k": 1, "R": 1.05, "PermGroFac": 1.1, "theta": 1, "CRRA": 2})
 
+    def test_attributions(self):
+        block_a_attributions = self.test_block_A.get_attributions()
+
+        self.assertEqual(block_a_attributions["consumer"], ["c", "u"])
+
+        cblock_attribtuions = self.cblock.get_attributions()
+
+        self.assertEqual(cblock_attribtuions["consumer"], ["c", "u"])
+
 
 class test_RBlock(unittest.TestCase):
     def setUp(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -24,11 +24,20 @@ test_block_A_data = {
     "reward": {"u": "consumer"},
 }
 
-test_block_B_data = {"name": "test block B", "shocks": {"SB": Bernoulli(p=0.1)}}
+test_block_B_data = {
+    "name": "test block B",
+    "shocks": {"SB": Bernoulli(p=0.1)},
+    "dynamics": {"pi": lambda a, Rfree: (Rfree - 1) * a},
+    "reward": {"pi": "lender"},
+}
 
 test_block_C_data = {"name": "test block B", "shocks": {"SC": Bernoulli(p=0.2)}}
 
-test_block_D_data = {"name": "test block D", "shocks": {"SD": Bernoulli(p=0.3)}}
+test_block_D_data = {
+    "name": "test block D",
+    "shocks": {"SD": Bernoulli(p=0.3)},
+    "dynamics": {"z": Control(["y"], agent="foo-agent")},
+}
 
 
 class test_Control(unittest.TestCase):
@@ -128,3 +137,12 @@ class test_RBlock(unittest.TestCase):
         self.assertFalse(
             isinstance(self.cpp.get_shocks()["theta"], DiscreteDistribution)
         )
+
+    def test_get_attributions(self):
+        r_block_tree = model.RBlock(
+            blocks=[self.test_block_B, self.test_block_C, self.test_block_D]
+        )
+
+        attrs = r_block_tree.get_attributions()
+
+        self.assertEqual({"foo-agent": ["z"], "lender": ["pi"]}, attrs)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,6 +30,16 @@ test_block_C_data = {"name": "test block B", "shocks": {"SC": Bernoulli(p=0.2)}}
 test_block_D_data = {"name": "test block D", "shocks": {"SD": Bernoulli(p=0.3)}}
 
 
+class test_Control(unittest.TestCase):
+    def setUp(self):
+        self.test_control_A = model.Control(
+            ["a"], upper_bound=lambda a: a, lower_bound=lambda a: 0, agent="myagent"
+        )
+
+    def test_attributes(self):
+        self.assertEqual(self.test_control_A.agent, "myagent")
+
+
 class test_DBlock(unittest.TestCase):
     def setUp(self):
         self.test_block_A = model.DBlock(**test_block_A_data)

--- a/tests/test_vbi.py
+++ b/tests/test_vbi.py
@@ -16,8 +16,9 @@ block_1 = DBlock(
             "m": lambda y, coin: y + coin,
             "c": Control(["m"], lower_bound=lambda m: 0, upper_bound=lambda m: m),
             "a": lambda m, c: m - c,
+            "u": lambda c: 1 - (c - 1) ** 2,
         },
-        "reward": {"u": lambda c: 1 - (c - 1) ** 2},
+        "reward": {"u": "agent"},
     }
 )
 
@@ -30,8 +31,9 @@ block_2 = DBlock(  # has no control variable
         "dynamics": {
             "m": lambda y, coin: y + coin,
             "a": lambda m: m - 1,
+            "u": lambda m: 0,
         },
-        "reward": {"u": lambda m: 0},
+        "reward": {"u": "agent"},
     }
 )
 


### PR DESCRIPTION
Fixes #20 

This alters DBlock and RBlock. Now, the structural equations for reward variables are listed in 'dynamics' just like other state variables. The `reward` attribute of a Block attributes some variables to particular agents. The Control object also has an attribution. Blocks have a method for getting all attributed variables.

Requesting review from @alanlujan91 

Please note @panpan17 that this provides a way of extract variable attributions directly from the Block object. This might interact with your visualizer in #19, allowing for a tighter integration.