### PR TITLE
implementation of lifetime reward estimator

### DIFF
--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -1,0 +1,112 @@
+import numpy as np
+import torch
+
+"""
+Tools for the implementation of the Maliar, Maliar, and Winant (JME '21) method.
+
+This method relies on a simpler problem representation than that elaborated
+by the skagent Block system.
+
+"""
+
+
+def create_transition_function(block, state_syms):
+    """
+    block
+    state_syms : list of string
+        A list of symbols for 'state variables at time t', aka arrival states.
+    """
+
+    def transition_function(states_t, controls_t, parameters={}):
+        vals = parameters | states_t | controls_t
+        post = block.transition(vals, {}, screen=True)
+
+        return {sym: post[sym] for sym in state_syms}
+
+    return transition_function
+
+
+def create_decision_function(block, decision_rules):
+    """
+    block
+    decision_rules
+    """
+
+    def decision_function(states_t, parameters={}):
+        vals = parameters | states_t
+        post = block.transition(vals, decision_rules)
+
+        return {sym: post[sym] for sym in decision_rules}
+
+    return decision_function
+
+
+def create_reward_function(block):
+    def reward_function(states_t, controls_t, parameters={}):
+        vals_t = parameters | states_t | controls_t
+        post = block.transition(vals_t, {}, screen=True)
+        return {sym: post[sym] for sym in block.reward}
+
+    return reward_function
+
+
+def estimate_discounted_lifetime_reward(
+    block, discount_factor, dr, states_0, big_t, parameters={}, agent=None
+):
+    """
+    block
+    discount_factor - can be a number or a function of state variables
+    dr - decision rule
+    states_0 - initial states
+    big_t - integer. Number of time steps to simulate forward
+    parameters - optional - calibration parameters
+    agent - optional - name of reference agent for rewards
+    """
+    states_t = states_0
+    total_discounted_reward = 0
+
+    tf = create_transition_function(block, list(states_0.keys()))
+
+    # preparing decision function
+    df = create_decision_function(block, dr)
+
+    # preparing reward function
+    # TODO: Can move this up to the function above.
+    if agent is None:
+        # assumes only one reward per block, not fully general
+        # TODO: fix this to use all reward variables
+        rsym = list(block.reward.keys())[0]
+    else:
+        # get the rsym corresponding to the given agent
+        # again, assumes only one reward symbol.
+        # TODO: make more general
+        rsym = [rsym for rsym in block.reward if block.reward[rsym] == agent][0]
+
+    rf = create_reward_function(block)
+
+    if callable(discount_factor):
+        raise Exception(
+            "Currently only numerical, not state-dependent, discount factors are supported."
+        )
+
+    for t in range(big_t):
+        controls_t = df(states_t, parameters=parameters)
+        reward_t = rf(states_t, controls_t, parameters=parameters)
+
+        # assumes torch
+        if isinstance(reward_t[rsym], torch.Tensor) and torch.any(
+            torch.isnan(reward_t[rsym])
+        ):
+            raise Exception(f"Calculated reward {[rsym]} is NaN: {reward_t}")
+        if isinstance(reward_t[rsym], np.ndarray) and np.any(np.isnan(reward_t[rsym])):
+            raise Exception(f"Calculated reward {[rsym]} is NaN: {reward_t}")
+
+        total_discounted_reward += reward_t[rsym] * discount_factor**t
+        # t + 1
+
+        ###
+        ### TODO: get these transition functions from the DBlock.
+        ###
+        states_t = tf(states_t, controls_t, parameters=parameters)
+
+    return total_discounted_reward

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -1,0 +1,87 @@
+import numpy as np
+import skagent.algos.maliar as solver
+import skagent.model as model
+import unittest
+
+parameters = {"q": 1.1}
+
+block_data = {
+    "name": "test block - maliar",
+    "dynamics": {
+        "c": model.Control(["a"]),
+        "a": lambda a, c, e, q: q * a - c + e,
+        "e": lambda e: e,
+        "u": lambda c: np.log(c),
+    },
+    "reward": {"u": "consumer"},
+}
+
+states_0 = {
+    "a": 1,
+    "e": 0.1,
+}
+
+# a dummy policy
+decision_rules = {"c": lambda a: a / 2}
+decisions = {"c": 0.5}
+
+
+class TestSolverFunctions(unittest.TestCase):
+    def setUp(self):
+        self.block = model.DBlock(**block_data)
+
+    def test_create_transition_function(self):
+        transition_function = solver.create_transition_function(self.block, ["a", "e"])
+
+        states_1 = transition_function(states_0, decisions, parameters=parameters)
+
+        self.assertAlmostEqual(states_1["a"], 0.7)
+        self.assertEqual(states_1["e"], 0.1)
+
+    def test_create_decision_function(self):
+        decision_function = solver.create_decision_function(self.block, decision_rules)
+
+        decisions_0 = decision_function(states_0, parameters=parameters)
+
+        self.assertEqual(decisions_0["c"], 0.5)
+
+    def test_create_reward_function(self):
+        reward_function = solver.create_reward_function(self.block)
+
+        reward_0 = reward_function(states_0, decisions, parameters=parameters)
+
+        self.assertAlmostEqual(reward_0["u"], -0.69314718)
+
+    def test_estimate_discounted_lifetime_reward(self):
+        dlr_0 = solver.estimate_discounted_lifetime_reward(
+            self.block,
+            0.9,
+            decision_rules,
+            states_0,
+            0,
+            parameters=parameters,
+        )
+
+        self.assertEqual(dlr_0, 0)
+
+        dlr_1 = solver.estimate_discounted_lifetime_reward(
+            self.block,
+            0.9,
+            decision_rules,
+            states_0,
+            1,
+            parameters=parameters,
+        )
+
+        self.assertAlmostEqual(dlr_1, -0.69314718)
+
+        dlr_2 = solver.estimate_discounted_lifetime_reward(
+            self.block,
+            0.9,
+            decision_rules,
+            states_0,
+            2,
+            parameters=parameters,
+        )
+
+        self.assertAlmostEqual(dlr_2, -1.63798709)


### PR DESCRIPTION
This PR addresses issue #22 : it implements a lifetime reward estimator function that takes a `block` as the key source of model information. (It also takes a discount factor, decision rule, and a few other arguments.)

This is the most basic kind of loss function for the Maliar method.

This involves a little bit of translation of the structural equations of `block` into transition and decision functions of the form expected by the Maliar method. This turns out to be easily handled by light wrappers around the existing `block` transition function.