### PR TITLE
aggregate_net_loss now uses vector/tensorized loss_function, fixes #35

### DIFF
--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -107,7 +107,6 @@ def estimate_discounted_lifetime_reward(
         )
 
     for t in range(big_t):
-        # TODO
         if shocks_by_t is not None:
             shocks_t = {sym: shocks_by_t[sym][t] for sym in shocks_by_t}
         else:

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -186,8 +186,8 @@ class test_ann_lr(unittest.TestCase):
             grid.make_grid(
                 {
                     "a": {"min": 0, "max": 1, "count": 5},
-                    "theta_0": {"min": -1, "max": 1, "count": 5},
-                    "psi_0": {"min": -1, "max": 1, "count": 3},
+                    "theta_0": {"min": -1, "max": 1, "count": 6},
+                    "psi_0": {"min": -1, "max": 1, "count": 4},
                     "theta_1": {"min": -1, "max": 1, "count": 5},
                     "psi_1": {"min": -1, "max": 1, "count": 3},
                 }
@@ -195,7 +195,7 @@ class test_ann_lr(unittest.TestCase):
         )
 
         bpn = ann.BlockPolicyNet(case_3["block"], width=8)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=200)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
 
         c_ann = bpn.decision_function(
             {"a": given_0_N[:, 0]},


### PR DESCRIPTION
Fixes #35 by making tweaks so that `aggregate_net_loss` passes the full tensor of inputs to the loss function, rather than iterating and stacking. This speeds up the computation by several orders of magnitude.