### PR TITLE
implementation of the Maliar method training loop with resampling of state spaces.

### DIFF
--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -179,23 +179,6 @@ def get_estimated_discounted_lifetime_reward_loss(
     return estimated_discounted_lifetime_reward_loss
 
 
-def generate_givens_from_state_config(state_config, block, shock_copies: int):
-    """
-    Generates omega_i values of the MMW JME '21 method.
-
-    state_config : a grid configuration for the starting state values (exogenous and endogenous)
-    block: block information (used to get the shock names)
-    shock_copies : int - number of copies of the shocks to be included.
-    """
-
-    # TODO: create a grid with the states, and shock_copies copies of the shocks.
-    #       - how are these values to be set?
-    #       - by sampling?
-    raise Exception("generate_givens_from_states not implemented")
-
-    pass
-
-
 def generate_givens_from_states(states: Grid, block: model.Block, shock_copies: int):
     """
     Generates omega_i values of the MMW JME '21 method.

--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -1,4 +1,7 @@
 import numpy as np
+import skagent.ann as ann
+import skagent.model as model
+from skagent.simulation.monte_carlo import draw_shocks
 import torch
 
 """
@@ -15,6 +18,7 @@ def create_transition_function(block, state_syms):
     block
     state_syms : list of string
         A list of symbols for 'state variables at time t', aka arrival states.
+        # TODO: state variables should be derived from the block analysis.
     """
 
     def transition_function(states_t, shocks_t, controls_t, parameters):
@@ -129,3 +133,165 @@ def estimate_discounted_lifetime_reward(
         states_t = tf(states_t, shocks_t, controls_t, parameters)
 
     return total_discounted_reward
+
+
+def get_estimated_discounted_lifetime_reward_loss(
+    state_variables, block, discount_factor, big_t, parameters
+):
+    # TODO: Should be able to get 'state variables' from block
+    # Maybe with ZP's analysis modules
+
+    # convoluted
+    # TODO: codify this encoding and decoding of the grid into a separate object
+    # It is specifically the EDLR loss function that requires big_t of the shocks.
+    # other AiO loss functions use 2 copies of the shocks only.
+    shock_vars = block.get_shocks()
+    big_t_shock_syms = sum(
+        [[f"{sym}_{t}" for sym in list(shock_vars.keys())] for t in range(big_t)], []
+    )
+
+    # will work for big_t = 1 only.
+    given_syms = state_variables + big_t_shock_syms
+
+    def estimated_discounted_lifetime_reward_loss(df, input_vector):
+        ## includes the values of state_0 variables, and shocks.
+        given_vals = dict(zip(given_syms, input_vector))
+
+        shock_vals = {sym: given_vals[sym] for sym in big_t_shock_syms}
+        shocks_by_t = {
+            sym: torch.stack([shock_vals[f"{sym}_{t}"] for t in range(big_t)])
+            for sym in shock_vars
+        }
+
+        ####block, discount_factor, dr, states_0, big_t, parameters={}, agent=None
+        edlr = estimate_discounted_lifetime_reward(
+            block,
+            discount_factor,
+            df,
+            {sym: given_vals[sym] for sym in state_variables},
+            big_t,
+            parameters=parameters,
+            agent=None,  ## TODO: Pass through the agent?
+            shocks_by_t=shocks_by_t,
+            ## Handle multiple decision rules?
+        )
+        return -edlr
+
+    return estimated_discounted_lifetime_reward_loss
+
+
+def generate_givens_from_state_config(state_config, block, shock_copies: int):
+    """
+    Generates omega_i values of the MMW JME '21 method.
+
+    state_config : a grid configuration for the starting state values (exogenous and endogenous)
+    block: block information (used to get the shock names)
+    shock_copies : int - number of copies of the shocks to be included.
+    """
+
+    # TODO: create a grid with the states, and shock_copies copies of the shocks.
+    #       - how are these values to be set?
+    #       - by sampling?
+    raise Exception("generate_givens_from_states not implemented")
+
+    pass
+
+
+def generate_givens_from_states(states, block, shock_copies: int):
+    """
+    Generates omega_i values of the MMW JME '21 method.
+
+    states : a grid of starting state values (exogenous and endogenous)
+    block: block information (used to get the shock names)
+    shock_copies : int - number of copies of the shocks to be included.
+    """
+
+    # TODO: create a grid with the states, and shock_copies copies of the shocks.
+    #       - how are these values to be set?
+    #       - by sampling?
+    raise Exception("generate_givens_from_states not implemented")
+
+    pass
+
+
+def simulate_forward(
+    states_t,
+    block: model.Block,
+    decision_function: callable,
+    parameters,
+    big_t,
+    state_syms,
+):
+    tf = create_transition_function(block, state_syms)
+
+    for t in range(big_t):
+        # TODO: make sure block shocks are 'constructed'
+        # TODO: allow option for 'structured' draws, e.g. from exact discretization.
+        shocks_t = draw_shocks(block.shocks)
+        decision_function(states_t, shocks_t, parameters)
+
+        states_t_plus_1 = tf(...)
+        states_t = states_t_plus_1
+
+    return states_t_plus_1
+
+
+def maliar_training_loop(
+    block,
+    loss_function,
+    states_0_n,
+    parameters,
+    shock_copies=2,
+    max_iterations=None,
+    random_seed=None,
+):
+    """
+    block - a model definition
+    loss_function : callable((df, input_vector) -> loss vector
+    states_0_n : a panel of starting states
+    parameters : dict : given parameters for the model
+
+    shock_copies: int : number of copies of shocks to include in the training set omega
+                        must match expected number of shock copies in the loss function
+                        TODO: make this better, less ad hoc
+
+    loss_function is the "empirical risk Xi^n" in MMW JME'21.
+    """
+
+    # Step 1. Initialize the algorithm:
+
+    # i). construct theoretical risk Xi(θ ) = Eω [ξ (ω; θ )] (lifetime reward, Euler/Bellmanequations);
+    # ii). deﬁne empirical risk Xi^n (θ ) = 1n ni=1 ξ (ωi ; θ );
+    loss_function  # This is provided as an argument.
+
+    # iii). deﬁne a topology of neural network ϕ (·, θ );
+    # iv). ﬁx initial vector of the coeﬃcients θ .
+
+    if random_seed is not None:
+        torch.manual_seed(random_seed)
+
+    bpn = ann.BlockPolicyNet(block, width=16)
+
+    states = states_0_n  # V) Create initial panel of agents/starting states.
+
+    # Step 2. Train the machine, i.e., ﬁnd θ that minimizes theempirical risk Xi^n (θ ):
+    for i in range(100):
+        # i). simulate the model to produce data {ωi }ni=1 by using the decision rule ϕ (·, θ );
+        givens = generate_givens_from_states(states_0_n, block, shock_copies)
+
+        # ii). construct the gradient ∇ Xi^n (θ ) = 1n ni=1 ∇ ξ (ωi ; θ );
+        # iii). update the coeﬃcients θ_hat = θ − λk ∇ Xi^n (θ ) and go to step 2.i);
+        # TODO how many epochs? What Adam scale? Passing through variables
+        ann.train_block_policy_nn(bpn, givens, loss_function, epochs=250)
+
+        # i/iv). simulate the model to produce data {ωi }ni=1 by using the decision rule ϕ (·, θ );
+        # TODO using SHOCKS (maybe new shocks), and ANN.DF, _transition the agents forward...
+        states = simulate_forward(
+            states, block, bpn.get_decision_function(), parameters
+        )
+
+        # End Step 2 if the convergence criterion || θ_hat − θ ||  < ε is satisﬁed.
+        # TODO: test for difference.. how? This effects the FOR (/while) loop above.
+
+    # Step 3. Assess the accuracy of constructed approximation ϕ (·, θ ) on a new sample.
+    return ann, states

--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -1,5 +1,6 @@
 import numpy as np
 import skagent.ann as ann
+from skagent.grid import Grid
 import skagent.model as model
 from skagent.simulation.monte_carlo import draw_shocks
 import torch
@@ -150,12 +151,9 @@ def get_estimated_discounted_lifetime_reward_loss(
         [[f"{sym}_{t}" for sym in list(shock_vars.keys())] for t in range(big_t)], []
     )
 
-    # will work for big_t = 1 only.
-    given_syms = state_variables + big_t_shock_syms
-
-    def estimated_discounted_lifetime_reward_loss(df, input_vector):
+    def estimated_discounted_lifetime_reward_loss(df: callable, input_grid: Grid):
         ## includes the values of state_0 variables, and shocks.
-        given_vals = dict(zip(given_syms, input_vector))
+        given_vals = input_grid.to_dict()
 
         shock_vals = {sym: given_vals[sym] for sym in big_t_shock_syms}
         shocks_by_t = {

--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -1,3 +1,4 @@
+from skagent.grid import Grid
 import torch
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -103,7 +104,7 @@ class BlockPolicyNet(Net):
 
 
 # General loss function that operates on tensor and averages over samples
-def aggregate_net_loss(inputs, df, loss_function):
+def aggregate_net_loss(inputs: Grid, df, loss_function):
     """
     Compute a loss function over a tensor of inputs, given a decision function df.
     Return the mean.
@@ -115,7 +116,9 @@ def aggregate_net_loss(inputs, df, loss_function):
     return losses.mean()
 
 
-def train_block_policy_nn(block_policy_nn, inputs, loss_function, epochs=50):
+def train_block_policy_nn(
+    block_policy_nn, inputs: Grid, loss_function: callable, epochs=50
+):
     ## to change
     # criterion = torch.nn.MSELoss()
     optimizer = torch.optim.Adam(block_policy_nn.parameters(), lr=0.01)  # Using Adam

--- a/src/skagent/grid.py
+++ b/src/skagent/grid.py
@@ -29,7 +29,7 @@ class Grid:
 
     @classmethod
     def from_config(cls, config={}, torched=True):
-        return cls(list(config.keys()), make_grid(config), torched=torch)
+        return cls(list(config.keys()), make_grid(config), torched=torched)
 
     @classmethod
     def from_dict(cls, kv={}, torched=False):

--- a/src/skagent/grid.py
+++ b/src/skagent/grid.py
@@ -4,6 +4,7 @@ Tools for building state and shock space grids.
 
 import numpy as np
 import torch
+import skagent.utils as utils
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -32,7 +33,7 @@ class Grid:
 
     @classmethod
     def from_dict(cls, kv={}, torched=False):
-        vals = [reconcile(list(kv.values())[0], val) for val in list(kv.values())]
+        vals = [utils.reconcile(list(kv.values())[0], val) for val in list(kv.values())]
 
         if isinstance(vals[0], np.ndarray):
             vals_stacked = np.stack(vals).T
@@ -86,34 +87,11 @@ class Grid:
         # TODO: fix the dict creation step to improve performance
         return self.to_dict()[sym]
 
+    # TODO: To imitate dict-like properties, may need to implement __contains__ and __iter__
+    #       or alternatively rewrite to use a Mappable base class.
 
-def reconcile(vec_a, vec_b):
-    """
-    Returns a new vector with the values of vec_b but with
-    the object type and shape of vec_a.
-    """
-    target_shape = vec_a.shape
-
-    if isinstance(vec_a, np.ndarray):
-        if isinstance(vec_b, torch.Tensor):
-            vec_b_np = vec_b.cpu().numpy()
-        else:
-            vec_b_np = vec_b
-
-        if vec_b_np.shape == target_shape:
-            return vec_b_np
-        else:
-            return vec_b_np.reshape(target_shape)
-    if isinstance(vec_a, torch.Tensor):
-        if isinstance(vec_b, np.ndarray):
-            vec_b_torch = torch.FloatTensor(vec_b).to(vec_a.device)
-        else:
-            vec_b_torch = vec_b.to(vec_a.device)
-
-        if vec_b_torch.shape == target_shape:
-            return vec_b_torch
-        else:
-            return vec_b_torch.reshape(target_shape)
+    def __str__(self):
+        return f"<skagent.grid.Grid: {self.to_dict()}"
 
 
 def make_grid(config):

--- a/src/skagent/simulation/monte_carlo.py
+++ b/src/skagent/simulation/monte_carlo.py
@@ -20,7 +20,7 @@ from skagent.utils import apply_fun_to_vals
 
 
 def draw_shocks(
-    shocks: Mapping[str, Distribution], conditions: Sequence[int] = (), n=1
+    shocks: Mapping[str, Distribution], conditions: Sequence[int] = (), n=None
 ):
     """
     Draw from each shock distribution values, subject to given conditions.

--- a/src/skagent/simulation/monte_carlo.py
+++ b/src/skagent/simulation/monte_carlo.py
@@ -20,7 +20,7 @@ from skagent.utils import apply_fun_to_vals
 
 
 def draw_shocks(
-    shocks: Mapping[str, Distribution], conditions: Sequence[int] = (), n=None
+    shocks: Mapping[str, Distribution], conditions: Sequence[int] = (), n=1
 ):
     """
     Draw from each shock distribution values, subject to given conditions.

--- a/src/skagent/simulation/monte_carlo.py
+++ b/src/skagent/simulation/monte_carlo.py
@@ -19,7 +19,9 @@ from skagent.model import construct_shocks, simulate_dynamics
 from skagent.utils import apply_fun_to_vals
 
 
-def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
+def draw_shocks(
+    shocks: Mapping[str, Distribution], conditions: Sequence[int] = (), n=None
+):
     """
     Draw from each shock distribution values, subject to given conditions.
 
@@ -33,6 +35,9 @@ def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
         Typically these will be agent ages.
         # TODO: generalize this to wider range of inputs.
 
+    n : int (optional)
+        Number of draws to do. An alternative to a conditions sequence.
+
     Parameters
     ------------
     draws : Mapping[str, Sequence]
@@ -40,11 +45,14 @@ def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
     """
     draws = {}
 
+    if n is None:
+        n = len(conditions)
+
     for shock_var in shocks:
         shock = shocks[shock_var]
 
         if isinstance(shock, (int, float)):
-            draws[shock_var] = np.ones(len(conditions)) * shock
+            draws[shock_var] = np.ones(n) * shock
         elif isinstance(shock, Aggregate):
             draws[shock_var] = shock.dist.draw(1)[0]
         elif isinstance(shock, IndexDistribution) or isinstance(
@@ -53,7 +61,7 @@ def draw_shocks(shocks: Mapping[str, Distribution], conditions: Sequence[int]):
             ## TODO  his type test is awkward. They should share a superclass.
             draws[shock_var] = shock.draw(conditions)
         else:
-            draws[shock_var] = shock.draw(len(conditions))
+            draws[shock_var] = shock.draw(n)
             # this is hacky if there are no conditions.
 
     return draws

--- a/src/skagent/utils.py
+++ b/src/skagent/utils.py
@@ -1,4 +1,6 @@
 from inspect import signature
+import numpy as np
+import torch
 
 
 def apply_fun_to_vals(fun, vals):
@@ -15,3 +17,32 @@ def apply_fun_to_vals(fun, vals):
     vals: dict
     """
     return fun(*[vals[var] for var in signature(fun).parameters])
+
+
+def reconcile(vec_a, vec_b):
+    """
+    Returns a new vector with the values of vec_b but with
+    the object type and shape of vec_a.
+    """
+    target_shape = vec_a.shape
+
+    if isinstance(vec_a, np.ndarray):
+        if isinstance(vec_b, torch.Tensor):
+            vec_b_np = vec_b.cpu().numpy()
+        else:
+            vec_b_np = vec_b
+
+        if vec_b_np.shape == target_shape:
+            return vec_b_np
+        else:
+            return vec_b_np.reshape(target_shape)
+    if isinstance(vec_a, torch.Tensor):
+        if isinstance(vec_b, np.ndarray):
+            vec_b_torch = torch.FloatTensor(vec_b).to(vec_a.device)
+        else:
+            vec_b_torch = vec_b.to(vec_a.device)
+
+        if vec_b_torch.shape == target_shape:
+            return vec_b_torch
+        else:
+            return vec_b_torch.reshape(target_shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,3 +119,37 @@ case_3 = {
         ),
     },
 }
+
+case_4 = {
+    "block": DBlock(
+        **{
+            "name": "maliar test - non-trivial ergodic states",
+            "shocks": {
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+                "psi": (Normal, {"mu": 0, "sigma": 1}),
+            },
+            "dynamics": {
+                "c": Control(["g", "m"]),
+                "a": lambda m, c: m - c,
+                "u": lambda a, g: -((a - g) ** 2),
+                "m": lambda a, theta: a + theta,
+                "g": lambda g, psi: g + psi,
+            },
+            "reward": {"u": "consumer"},
+        }
+    ),
+    "optimal_dr": {"c": lambda g, m: g - m},
+    "calibration": {},
+    "givens": {
+        2: grid.Grid.from_config(
+            {
+                "m": {"min": -100, "max": 100, "count": 7},
+                "g": {"min": -100, "max": 100, "count": 7},
+                "theta_0": {"min": -1, "max": 1, "count": 7},
+                "psi_0": {"min": -1, "max": 1, "count": 7},
+                "theta_1": {"min": -1, "max": 1, "count": 5},
+                "psi_1": {"min": -1, "max": 1, "count": 5},
+            }
+        ),
+    },
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ case_0 = {
     ),
     "calibration": {},
     "optimal_dr": {"c": lambda a: 0},
-    "givens": grid.Grid(
+    "givens": grid.Grid.from_config(
         {
             "a": {"min": 0, "max": 2, "count": 21},
         }
@@ -27,7 +27,7 @@ case_1 = {
         **{
             "name": "lr_test_1 - shock",
             "shocks": {
-                "theta": (Normal, {"mean": 0, "sigma": 1}),
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
             },
             "dynamics": {
                 "c": Control(["a", "theta"]),
@@ -40,13 +40,13 @@ case_1 = {
     "calibration": {},
     "optimal_dr": {"c": lambda a, theta: theta},
     "givens": {
-        1: grid.Grid(
+        1: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 7},
                 "theta_0": {"min": -1, "max": 1, "count": 7},
             }
         ),
-        2: grid.Grid(
+        2: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 7},
                 "theta_0": {"min": -1, "max": 1, "count": 7},
@@ -61,7 +61,7 @@ case_2 = {
         **{
             "name": "lr_test_2 - hidden shock",
             "shocks": {
-                "theta": (Normal, {"mean": 0, "sigma": 1}),
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
             },
             "dynamics": {
                 "c": Control(["a"]),
@@ -73,7 +73,7 @@ case_2 = {
     ),
     "calibration": {},
     "optimal_dr": {"c": lambda a: 0},
-    "givens": grid.Grid(
+    "givens": grid.Grid.from_config(
         {
             "a": {"min": 0, "max": 1, "count": 5},
             "theta_0": {"min": -1, "max": 1, "count": 5},
@@ -86,8 +86,8 @@ case_3 = {
         **{
             "name": "lr_test_3 - two shocks, one hidden",
             "shocks": {
-                "theta": (Normal, {"mean": 0, "sigma": 1}),
-                "psi": (Normal, {"mean": 0, "sigma": 1}),
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+                "psi": (Normal, {"mu": 0, "sigma": 1}),
             },
             "dynamics": {
                 "m": lambda a, theta: a + theta,
@@ -101,14 +101,14 @@ case_3 = {
     "optimal_dr": {"c": lambda m: m},
     "calibration": {},
     "givens": {
-        1: grid.Grid(
+        1: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 5},
                 "theta_0": {"min": -1, "max": 1, "count": 5},
                 "psi_0": {"min": -1, "max": 1, "count": 5},
             }
         ),
-        2: grid.Grid(
+        2: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 5},
                 "theta_0": {"min": -1, "max": 1, "count": 5},

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -185,7 +185,7 @@ class test_ann_lr(unittest.TestCase):
 
         ### Setting up the training
 
-        states_0_N = grid.Grid(
+        states_0_N = grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 3, "count": 5},
                 "p": {"min": 0, "max": 1, "count": 4},

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -144,7 +144,7 @@ class test_ann_lr(unittest.TestCase):
         )["c"]
         given_m = given_0_N["a"] + given_0_N["theta_0"]
 
-        torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.03)
+        self.assertTrue(torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.03))
 
     def test_case_3_2(self):
         edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
@@ -170,7 +170,7 @@ class test_ann_lr(unittest.TestCase):
         )["c"]
         given_m = given_0_N["a"] + given_0_N["theta_0"]
 
-        torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.04)
+        self.assertTrue(torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.04))
 
     def test_lifetime_reward_perfect_foresight(self):
         ### Model data

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -1,4 +1,5 @@
 from conftest import case_0, case_1, case_2, case_3
+import skagent.algos.maliar as maliar
 import skagent.ann as ann
 import skagent.grid as grid
 import skagent.models.perfect_foresight as pfm
@@ -19,7 +20,7 @@ class test_ann_lr(unittest.TestCase):
         pass
 
     def test_case_0(self):
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_0["block"],
             0.9,
@@ -42,7 +43,7 @@ class test_ann_lr(unittest.TestCase):
         )
 
     def test_case_1(self):
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_1["block"],
             0.9,
@@ -73,7 +74,7 @@ class test_ann_lr(unittest.TestCase):
         """
         Running case 1 with big_t == 2
         """
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_1["block"],
             0.9,
@@ -101,7 +102,7 @@ class test_ann_lr(unittest.TestCase):
         )
 
     def test_case_2(self):
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_2["block"],
             0.9,
@@ -120,7 +121,7 @@ class test_ann_lr(unittest.TestCase):
         # actually gives no information, training isn't effective...
 
     def test_case_3(self):
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_3["block"],
             0.9,
@@ -146,7 +147,7 @@ class test_ann_lr(unittest.TestCase):
         torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.03)
 
     def test_case_3_2(self):
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             ["a"],
             case_3["block"],
             0.9,
@@ -178,7 +179,7 @@ class test_ann_lr(unittest.TestCase):
         state_variables = ["a", "p"]
 
         ### Loss function
-        edlrl = ann.get_estimated_discounted_lifetime_reward_loss(
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
             state_variables, pfblock, 0.9, 1, parameters=pfm.calibration
         )
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,6 +1,8 @@
 import unittest
 
+import numpy as np
 import skagent.grid as grid
+import torch
 
 
 class test_make_grid(unittest.TestCase):
@@ -31,3 +33,76 @@ class test_make_grid(unittest.TestCase):
         g = grid.make_grid(triple)
 
         self.assertEqual(g.shape, (125, 3))
+
+
+class test_grid_alt_constructors(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "a": {"max": 1, "min": 0, "count": 5},
+            "b": {"max": 1, "min": 0, "count": 3},
+        }
+
+        self.dict_a_np = {"a": np.array([0.25, 0.5, 0.75])}
+
+        self.dict_a_torch = {"a": torch.FloatTensor(np.array([0.25, 0.5, 0.75]))}
+
+        self.dict_b_np = {"b": np.array([0, 0.5, 1])}
+
+        self.dict_b_torch = {"b": torch.FloatTensor(np.array([0, 0.5, 1]))}
+
+        self.dict_b_np_2d = {"b": np.array([[0, 0.5, 1]])}
+
+    def test_from_config(self):
+        g = grid.Grid.from_config(self.config)
+
+        self.assertEqual(g.len(), 2)
+        self.assertEqual(g.n(), 15)
+
+    def test_from_dict_numpy(self):
+        g = grid.Grid.from_dict(self.dict_b_np)
+
+        self.assertEqual(g.len(), 1)
+        self.assertEqual(g.n(), 3)
+
+    def test_from_dict_torch(self):
+        g = grid.Grid.from_dict(self.dict_b_torch)
+
+        self.assertEqual(g.len(), 1)
+        self.assertEqual(g.n(), 3)
+
+    def test_from_dict_mixed_np_first(self):
+        kv = {**self.dict_a_np, **self.dict_b_torch}
+
+        g = grid.Grid.from_dict(kv)
+
+        self.assertEqual(g.len(), 2)
+        self.assertEqual(g.n(), 3)
+
+    def test_from_dict_mixed_torch_first(self):
+        kv = {**self.dict_a_torch, **self.dict_b_np}
+
+        g = grid.Grid.from_dict(kv)
+
+        self.assertEqual(g.len(), 2)
+        self.assertEqual(g.n(), 3)
+
+    def test_update_from_dict_np_first(self):
+        g = grid.Grid.from_dict(self.dict_a_np)
+        g2 = g.update_from_dict(self.dict_b_torch)
+
+        self.assertEqual(g2.len(), 2)
+        self.assertEqual(g2.n(), 3)
+
+    def test_update_from_dict_torch_first(self):
+        g = grid.Grid.from_dict(self.dict_a_torch)
+        g2 = g.update_from_dict(self.dict_b_np)
+
+        self.assertEqual(g2.len(), 2)
+        self.assertEqual(g2.n(), 3)
+
+    def test_update_from_dict_np_reshape(self):
+        g = grid.Grid.from_dict(self.dict_a_torch)
+        g2 = g.update_from_dict(self.dict_b_np_2d)
+
+        self.assertEqual(g2.len(), 2)
+        self.assertEqual(g2.n(), 3)

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -156,8 +156,7 @@ class TestGridManipulations(unittest.TestCase):
 
         full_grid = maliar.generate_givens_from_states(state_grid, block, 1)
 
-        self.assertTrue("theta_0" in full_grid)
-        self.assertEqual(len(full_grid["theta_0"]), 7)
+        self.assertEqual(full_grid["theta_0"].shape.numel(), 7)
 
     def test_givens_case_3(self):
         block = case_3["block"]
@@ -171,7 +170,6 @@ class TestGridManipulations(unittest.TestCase):
 
         full_grid = maliar.generate_givens_from_states(state_grid, block, 2)
 
-        self.assertTrue("psi_0" in full_grid)
         self.assertEqual(len(full_grid["psi_0"]), 7)
 
 
@@ -190,9 +188,7 @@ class TestTrainingLoop(unittest.TestCase):
             parameters=case_1["calibration"],
         )
 
-        states_0_n = grid.torched(
-            grid.make_grid({"a": {"min": 0, "max": 1, "count": 7}})
-        )
+        states_0_n = grid.Grid.from_config({"a": {"min": 0, "max": 1, "count": 7}})
 
         ann, states = maliar.maliar_training_loop(
             case_1["block"],
@@ -200,6 +196,7 @@ class TestTrainingLoop(unittest.TestCase):
             states_0_n,
             case_1["calibration"],
             shock_copies=big_t,
+            simulation_steps=5,
         )
 
         # Currently just a smoke test.

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -1,4 +1,4 @@
-from conftest import case_1, case_2, case_3
+from conftest import case_1, case_2, case_3, case_4
 import numpy as np
 import skagent.algos.maliar as maliar
 import skagent.grid as grid
@@ -177,26 +177,38 @@ class TestTrainingLoop(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_loop_case_1(self):
-        big_t = 3
+    def test_loop_case_4(self):
+        big_t = 2
+
+        case_4["block"].construct_shocks(case_4["calibration"])
+
+        states_0_n = grid.Grid.from_config(
+            {
+                "m": {"min": -2, "max": 2, "count": 7},
+                "g": {"min": -2, "max": 2, "count": 7},
+            }
+        )
 
         edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
-            ["a"],
-            case_1["block"],
+            states_0_n.labels,
+            case_4["block"],
             0.9,
             big_t,
-            parameters=case_1["calibration"],
+            parameters=case_4["calibration"],
         )
-
-        states_0_n = grid.Grid.from_config({"a": {"min": 0, "max": 1, "count": 7}})
 
         ann, states = maliar.maliar_training_loop(
-            case_1["block"],
+            case_4["block"],
             edlrl,
             states_0_n,
-            case_1["calibration"],
+            case_4["calibration"],
             shock_copies=big_t,
-            simulation_steps=5,
+            simulation_steps=2,
         )
 
-        # Currently just a smoke test.
+        sd = states.to_dict()
+
+        # testing for the states converged on the ergodic distribution
+        print(states.values)
+
+        self.assertTrue(torch.allclose(sd["m"], sd["g"], atol=0.1))

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -209,6 +209,4 @@ class TestTrainingLoop(unittest.TestCase):
         sd = states.to_dict()
 
         # testing for the states converged on the ergodic distribution
-        print(states.values)
-
         self.assertTrue(torch.allclose(sd["m"], sd["g"], atol=0.1))

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -1,4 +1,4 @@
-from conftest import case_1, case_2
+from conftest import case_1, case_2, case_3
 import numpy as np
 import skagent.algos.maliar as maliar
 import skagent.grid as grid
@@ -138,6 +138,43 @@ class TestLifetimeReward(unittest.TestCase):
         self.assertEqual(dlr_2, 0)
 
 
+class TestGridManipulations(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_givens_case_1(self):
+        # TODO: we're going to need to build the blocks in the test, because of this mutation,
+        #       or else make this return a copy.
+        block = case_1["block"]
+        block.construct_shocks(case_1["calibration"])
+
+        state_grid = grid.Grid.from_config(
+            {
+                "a": {"min": 0, "max": 1, "count": 7},
+            }
+        )
+
+        full_grid = maliar.generate_givens_from_states(state_grid, block, 1)
+
+        self.assertTrue("theta_0" in full_grid)
+        self.assertEqual(len(full_grid["theta_0"]), 7)
+
+    def test_givens_case_3(self):
+        block = case_3["block"]
+        block.construct_shocks(case_1["calibration"])
+
+        state_grid = grid.Grid.from_config(
+            {
+                "a": {"min": 0, "max": 1, "count": 7},
+            }
+        )
+
+        full_grid = maliar.generate_givens_from_states(state_grid, block, 2)
+
+        self.assertTrue("psi_0" in full_grid)
+        self.assertEqual(len(full_grid["psi_0"]), 7)
+
+
 class TestTrainingLoop(unittest.TestCase):
     def setUp(self):
         pass
@@ -164,3 +201,5 @@ class TestTrainingLoop(unittest.TestCase):
             case_1["calibration"],
             shock_copies=big_t,
         )
+
+        # Currently just a smoke test.


### PR DESCRIPTION
Addresses #47 

This PR works towards a complete implementation of the Maliar method (MMW JME '21) using:
 - generic Blocks
 - sampling of the state space that converges on the ergodic distribution, for the computation of the empirical loss function
 - reasonable parameters values for the training loop

I'm sticking with the estimated lifetime reward function for this PR; swapping in alternative loss functions is out of scope.
Though I hope to make the code general enough so that's easy.

I significant part of making this work is extending the Grid class to make it easier to extend or modify (immutably -- making a copy with changes). Constructing new training sets with state and shock samples is a key part of the method. These changes are in skagent.grid and have automated tests. This class is looking more and more like a `tensordict`, but I've taken pains to make it compatible with a pure numpy implementation. It's possible that tighter integration with `tensordict` is called for and would be useful down the line.

Some of the kludgy parts of the implementation would be more smoothly done if the model analyzer #38 were in the library, since that way 'state variables' could be isolated from the DBlock's other variables through algorithmic model inspection.