### PR TITLE
Normalize BlockPolicyNet by upper and lower bounds

### DIFF
--- a/src/skagent/model.py
+++ b/src/skagent/model.py
@@ -323,7 +323,7 @@ class DBlock(Block):
         """
         return list(self.shocks.keys()) + list(self.dynamics.keys())
 
-    def transition(self, pre, dr, screen=False, fix=None):
+    def transition(self, pre, dr, screen=False, until=None, fix=None):
         if fix is None:
             fix = []
         """
@@ -338,6 +338,10 @@ class DBlock(Block):
         screen: Boolean
             If True, the remove any dynamics that are prior to the first given state.
             Defaults to False.
+
+        until: str or None
+            If not None, a symb which is the last symbol to simulate forward.
+            Useful for not overwriting prestates with poststates.
 
         fix: list of string
             A list of symbols to make static, rather than dynamic.
@@ -361,6 +365,17 @@ class DBlock(Block):
             # i.e. if dynamics at time t for variable 'a'
             # depend on state of 'a' at time t-1
             # This is a forbidden case in CDC's design.
+
+        if until:
+            # don't simulate any states that are logically after
+            # the until state
+            met_until = False  # this is a hack; really should use dependency graph
+            for sym in list(dyn.keys()):
+                if not met_until:
+                    if sym == until:
+                        met_until = True
+                else:
+                    del dyn[sym]
 
         for sym in fix:
             if sym in dyn and sym in pre:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,105 @@ case_4 = {
         ),
     },
 }
+
+case_5 = {
+    "block": DBlock(
+        **{
+            "name": "double bounded control -- upper bound binds",
+            "shocks": {
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+            },
+            "dynamics": {
+                "c": Control(["a"], upper_bound=lambda a: a, lower_bound=lambda a: 0),
+                "a": lambda a, c, theta: a - c + 2.72**theta,
+                "u": lambda c: c,
+            },
+            "reward": {"u": "consumer"},
+        }
+    ),
+    "calibration": {},
+    "optimal_dr": {"c": lambda a: a},
+    "givens": grid.Grid.from_config(
+        {
+            "a": {"min": 0, "max": 1, "count": 5},
+            "theta_0": {"min": -1, "max": 1, "count": 5},
+        }
+    ),
+}
+
+case_6 = {
+    "block": DBlock(
+        **{
+            "name": "double bounded control -- lower bound binds",
+            "shocks": {
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+            },
+            "dynamics": {
+                "c": Control(
+                    ["a"], upper_bound=lambda a: 2 * a, lower_bound=lambda a: a
+                ),
+                "a": lambda a, c, theta: a + 2.72**theta,
+                "u": lambda c: -c,
+            },
+            "reward": {"u": "consumer"},
+        }
+    ),
+    "calibration": {},
+    "optimal_dr": {"c": lambda a: a},
+    "givens": grid.Grid.from_config(
+        {
+            "a": {"min": 0, "max": 1, "count": 5},
+            "theta_0": {"min": -1, "max": 1, "count": 5},
+        }
+    ),
+}
+
+case_7 = {
+    "block": DBlock(
+        **{
+            "name": "lower bounded control only",
+            "shocks": {
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+            },
+            "dynamics": {
+                "c": Control(["a"], lower_bound=lambda a: 1),
+                "a": lambda a, c, theta: a + 2.72**theta - c,
+                "u": lambda c: -c,
+            },
+            "reward": {"u": "consumer"},
+        }
+    ),
+    "calibration": {},
+    "optimal_dr": {"c": lambda a: 1},
+    "givens": grid.Grid.from_config(
+        {
+            "a": {"min": 0, "max": 1, "count": 5},
+            "theta_0": {"min": -1, "max": 1, "count": 5},
+        }
+    ),
+}
+
+case_8 = {
+    "block": DBlock(
+        **{
+            "name": "upper bounded control only",
+            "shocks": {
+                "theta": (Normal, {"mu": 0, "sigma": 1}),
+            },
+            "dynamics": {
+                "c": Control(["a"], upper_bound=lambda a: a),
+                "a": lambda a, c, theta: a + 2.72**theta - c,
+                "u": lambda c: c,
+            },
+            "reward": {"u": "consumer"},
+        }
+    ),
+    "calibration": {},
+    "optimal_dr": {"c": lambda a: a},
+    "givens": grid.Grid.from_config(
+        {
+            "a": {"min": 0, "max": 1, "count": 5},
+            "theta_0": {"min": -1, "max": 1, "count": 5},
+        }
+    ),
+}

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -1,4 +1,4 @@
-from conftest import case_0, case_1, case_2, case_3
+from conftest import case_0, case_1, case_2, case_3, case_5, case_6, case_7, case_8
 import skagent.algos.maliar as maliar
 import skagent.ann as ann
 import skagent.grid as grid
@@ -36,8 +36,6 @@ class test_ann_lr(unittest.TestCase):
         ann.train_block_policy_nn(bpn, states_0_N, edlrl, epochs=250)
 
         c_ann = bpn.decision_function(states_0_N.to_dict(), {}, {})["c"]
-
-        print(c_ann)
 
         # Is this result stochastic? How are the network weights being initialized?
         self.assertTrue(
@@ -97,7 +95,6 @@ class test_ann_lr(unittest.TestCase):
 
         errors = c_ann.flatten() - given_0_N["theta_0"]
 
-        print(errors)
         # Is this result stochastic? How are the network weights being initialized?
         self.assertTrue(
             torch.allclose(errors, torch.zeros(errors.shape).to(device), atol=0.03)
@@ -173,6 +170,104 @@ class test_ann_lr(unittest.TestCase):
         given_m = given_0_N["a"] + given_0_N["theta_0"]
 
         self.assertTrue(torch.allclose(c_ann.flatten(), given_m.flatten(), atol=0.04))
+
+    def test_case_5_double_bounded_upper_binds(self):
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
+            ["a"],
+            case_5["block"],
+            0.9,
+            1,
+            parameters=case_5["calibration"],
+        )
+
+        given_0_N = case_5["givens"]
+
+        bpn = ann.BlockPolicyNet(case_5["block"], width=8)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+
+        c_ann = bpn.decision_function(
+            {"a": given_0_N["a"]},
+            {"theta": given_0_N["theta_0"]},
+            {},
+        )["c"]
+
+        self.assertTrue(
+            torch.allclose(c_ann.flatten(), given_0_N["a"].flatten(), atol=0.03)
+        )
+
+    def test_case_6_double_bounded_lower_binds(self):
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
+            ["a"],
+            case_6["block"],
+            0.9,
+            1,
+            parameters=case_6["calibration"],
+        )
+
+        given_0_N = case_6["givens"]
+
+        bpn = ann.BlockPolicyNet(case_6["block"], width=8)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+
+        c_ann = bpn.decision_function(
+            {"a": given_0_N["a"]},
+            {"theta": given_0_N["theta_0"]},
+            {},
+        )["c"]
+
+        self.assertTrue(
+            torch.allclose(c_ann.flatten(), given_0_N["a"].flatten(), atol=0.03)
+        )
+
+    def test_case_7_only_lower_bound(self):
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
+            ["a"],
+            case_7["block"],
+            0.9,
+            1,
+            parameters=case_7["calibration"],
+        )
+
+        given_0_N = case_7["givens"]
+
+        bpn = ann.BlockPolicyNet(case_7["block"], width=8)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+
+        c_ann = bpn.decision_function(
+            {"a": given_0_N["a"]},
+            {"theta": given_0_N["theta_0"]},
+            {},
+        )["c"]
+
+        self.assertTrue(
+            torch.allclose(
+                c_ann.flatten(), torch.zeros(c_ann.shape).to(device) + 1, atol=0.03
+            )
+        )
+
+    def test_case_8_only_upper_bound(self):
+        edlrl = maliar.get_estimated_discounted_lifetime_reward_loss(
+            ["a"],
+            case_8["block"],
+            0.9,
+            1,
+            parameters=case_8["calibration"],
+        )
+
+        given_0_N = case_8["givens"]
+
+        bpn = ann.BlockPolicyNet(case_8["block"], width=8)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+
+        c_ann = bpn.decision_function(
+            {"a": given_0_N["a"]},
+            {"theta": given_0_N["theta_0"]},
+            {},
+        )["c"]
+
+        self.assertTrue(
+            torch.allclose(c_ann.flatten(), given_0_N["a"].flatten(), atol=0.03)
+        )
 
     def test_lifetime_reward_perfect_foresight(self):
         ### Model data

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -54,7 +54,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_1["givens"][1]
 
         bpn = ann.BlockPolicyNet(case_1["block"], width=16)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=350)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=600)
 
         c_ann = bpn.decision_function(
             # TODO -- make this from the Grid
@@ -85,7 +85,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_1["givens"][2]
 
         bpn = ann.BlockPolicyNet(case_1["block"], width=16)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=200)
+        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
 
         c_ann = bpn.decision_function(
             {"a": given_0_N["a"]},

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -75,6 +75,11 @@ class test_DBlock(unittest.TestCase):
 
         self.assertEqual(post["a"], 0)
 
+    def test_transition_until(self):
+        post = self.cblock.transition(self.dpre, self.dr, until="c")
+
+        self.assertTrue("u" not in post)
+
     def test_calc_reward(self):
         self.assertEqual(self.cblock.calc_reward({"c": 1, "CRRA": 2})["u"], -1.0)
 


### PR DESCRIPTION
This PR addresses #66 

Now, when a BlockPolicyNet is created for a block with a control that has an upper bound, lower bound, or both, the network will output a value within the bounds, and the gradients will work out properly so the policy can be trained into the binding constraints.

There are a few different contributions here:
- Test cases for bounded blocks in `conftest.py`
- Adding an optional `until` argument to `block.transition()` which let you simulate forward the block dynamics until hitting a particular symbol. This is important because to get at the values in the information set of the control, it's important to not overwrite the post-states, which are by definition downstream of the control.
- A new utility `utils.create_vectorized_function_wrapper_with_mapping` -- not elegantly named -- which wraps a function (here, the upper and lower bound functions) and a mapping from symbols to tensor indices, which allows the function to be executed properly in the 'scope' of the tensor. This is needed in the forward function of the neural network, where the normalization of the output happens given the input vector, as opposed to a `dict` representation of the inputs.
- The changes to `BlockPolicyNet` to implement the normalization. A lot of work happens on initialization. This also means overriding the default `forward` function of the `Net` class. This makes a cross-class assumption of network architecture, which is going to complicate #52 but so it goes.