### PR TITLE
static solver

### DIFF
--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -179,6 +179,80 @@ def get_estimated_discounted_lifetime_reward_loss(
     return estimated_discounted_lifetime_reward_loss
 
 
+def static_reward(
+    block,
+    dr,
+    states,
+    shocks={},
+    parameters={},
+    agent=None,
+):
+    """
+    Returns the reward for an agent for a block, given a decision rule, states, shocks, and calibration.
+
+    block
+    dr - decision rules (dict of functions), or optionally a decision function (a function that returns the decisions)
+    states - dict - initial states, symbols : values (scalars work; TODO: do vectors work here?)
+    shocks- dict - sym : vector of shock values
+        # TODO: Here the shocks are given. We will want to streamline a way of sampling here.
+    big_t - integer. Number of time steps to simulate forward
+    parameters - optional - calibration parameters
+    agent - optional - name of reference agent for rewards
+    """
+    if callable(dr):
+        # assume a full decision function has been passed in
+        df = dr
+    else:
+        # create a decision function from the decision rule
+        df = create_decision_function(block, dr)
+
+    rf = create_reward_function(block, agent)
+
+    # this assumes only one reward is given.
+    # can be generalized in the future.
+    rsym = list(
+        {sym for sym in block.reward if agent is None or block.reward[sym] == agent}
+    )[0]
+
+    controls = df(states, shocks, parameters)
+    reward = rf(states, shocks, controls, parameters)
+
+    # assumes torch
+    if isinstance(reward[rsym], torch.Tensor) and torch.any(torch.isnan(reward[rsym])):
+        raise Exception(f"Calculated reward {[rsym]} is NaN: {reward}")
+    if isinstance(reward[rsym], np.ndarray) and np.any(np.isnan(reward[rsym])):
+        raise Exception(f"Calculated reward {[rsym]} is NaN: {reward}")
+
+    return reward[rsym]
+
+
+def get_static_reward_loss(state_variables, block, parameters):
+    # TODO: Should be able to get 'state variables' from block
+    # Maybe with ZP's analysis modules
+
+    shock_vars = block.get_shocks()
+
+    def static_reward_loss(df: callable, input_grid: Grid):
+        ## includes the values of state_0 variables, and shocks.
+        given_vals = input_grid.to_dict()
+
+        shock_vals = {sym: input_grid[sym] for sym in shock_vars}
+
+        ####block, discount_factor, dr, states_0, big_t, parameters={}, agent=None
+        r = static_reward(
+            block,
+            df,
+            {sym: given_vals[sym] for sym in state_variables},
+            parameters=parameters,
+            agent=None,  ## TODO: Pass through the agent?
+            shocks=shock_vals,
+            ## Handle multiple decision rules?
+        )
+        return -r
+
+    return static_reward_loss
+
+
 def generate_givens_from_states(states: Grid, block: model.Block, shock_copies: int):
     """
     Generates omega_i values of the MMW JME '21 method.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,12 @@ case_1 = {
     "calibration": {},
     "optimal_dr": {"c": lambda a, theta: theta},
     "givens": {
+        0: grid.Grid.from_config(
+            {
+                "a": {"min": 0, "max": 1, "count": 7},
+                "theta_0": {"min": -1, "max": 1, "count": 7},
+            }
+        ),
         1: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 7},
@@ -75,8 +81,8 @@ case_2 = {
     "optimal_dr": {"c": lambda a: 0},
     "givens": grid.Grid.from_config(
         {
-            "a": {"min": 0, "max": 1, "count": 5},
-            "theta_0": {"min": -1, "max": 1, "count": 5},
+            "a": {"min": 0, "max": 1, "count": 11},
+            "theta_0": {"min": -1, "max": 1, "count": 11},
         }
     ),
 }
@@ -101,6 +107,13 @@ case_3 = {
     "optimal_dr": {"c": lambda m: m},
     "calibration": {},
     "givens": {
+        0: grid.Grid.from_config(
+            {
+                "a": {"min": 0, "max": 1, "count": 5},
+                "theta_0": {"min": -1, "max": 1, "count": 5},
+                "psi_0": {"min": -1, "max": 1, "count": 5},
+            }
+        ),
         1: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 5},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ case_1 = {
         0: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 7},
-                "theta_0": {"min": -1, "max": 1, "count": 7},
+                "theta": {"min": -1, "max": 1, "count": 7},
             }
         ),
         1: grid.Grid.from_config(
@@ -82,7 +82,7 @@ case_2 = {
     "givens": grid.Grid.from_config(
         {
             "a": {"min": 0, "max": 1, "count": 11},
-            "theta_0": {"min": -1, "max": 1, "count": 11},
+            "theta": {"min": -1, "max": 1, "count": 11},
         }
     ),
 }
@@ -110,8 +110,8 @@ case_3 = {
         0: grid.Grid.from_config(
             {
                 "a": {"min": 0, "max": 1, "count": 5},
-                "theta_0": {"min": -1, "max": 1, "count": 5},
-                "psi_0": {"min": -1, "max": 1, "count": 5},
+                "theta": {"min": -1, "max": 1, "count": 5},
+                "psi": {"min": -1, "max": 1, "count": 5},
             }
         ),
         1: grid.Grid.from_config(


### PR DESCRIPTION
Addresses #76 

The goal of this PR is to streamline the process for solving a 'static' model, meaning one in which the model's Block is not expected to repeat. Ideally, the 'building blocks' for this process can then be reused in more complex solvers, such as estimated lifetime reward and Bellman solvers.

This is rather straightforward to implement.

The main open questions, in my view, are how to organize the code so that it can be easier to navigate.

I put the `static_reward` and `static_reward_loss` methods in the `maliar.py` module despite their not being related to the MMW '21 method at all, because that's where parallel methods are.

I'm now thinking that many of the functions in this module, which essentially wrap the Block data with some functionality (such as creating decision and reward function, simulating forward, and now computing a reward loss for a block given a decision rules and vectors of states and shocks) can all be moved into a more generic `solver.py` module.