### PR TITLE
adding method to Block to get arrival states (i.e. lag variables)

### DIFF
--- a/src/skagent/model.py
+++ b/src/skagent/model.py
@@ -13,6 +13,7 @@ from skagent.distributions import (
 from inspect import signature
 import numpy as np
 from skagent.parser import math_text_to_lambda
+from skagent.rule import extract_dependencies
 from typing import Any, Callable, Mapping, List, Union
 
 
@@ -179,9 +180,9 @@ def simulate_dynamics(
 
     for sym in dynamics:
         # Using the fact that Python dictionaries are ordered
-        feq = dynamics[sym]
+        update_fn = dynamics[sym]
 
-        if isinstance(feq, Control):
+        if isinstance(update_fn, Control):
             # This tests if the decision rule is age varying.
             # If it is, this will be a vector with the decision rule for each agent.
             if isinstance(dr[sym], np.ndarray):
@@ -204,7 +205,7 @@ def simulate_dynamics(
                     try:
                         vals[sym] = dr[sym](
                             *[
-                                vals[var] for var in feq.iset
+                                vals[var] for var in update_fn.iset
                             ]  # signature(dr[sym]).parameters]
                         )  # TODO: test for signature match with Control
                     except (TypeError, ValueError, KeyError) as e:
@@ -214,7 +215,9 @@ def simulate_dynamics(
                     # easy to compute in any scope...
                     vals[sym] = dr[sym]()
         else:
-            vals[sym] = feq(*[vals[var] for var in signature(feq).parameters])
+            vals[sym] = update_fn(
+                *[vals[var] for var in signature(update_fn).parameters]
+            )
 
     return vals
 
@@ -252,6 +255,40 @@ class Block:
         dyn = self.get_dynamics()
 
         return {sym: dyn[sym] for sym in dyn if isinstance(dyn[sym], Control)}
+
+    def get_arrival_states(self, calibration=None):
+        """
+        Return a list of symbols that are:
+          - required by the dynamic equations of the block
+          - dynamic variables themselves (controlled by dynamic equations)
+
+        This is the list of symbols that are implicitly 'lagged',
+        or must be provided 'on arrival'.
+
+        Parameters
+        -----------
+
+        calibration: dict, optional
+            A dictionary of parameters used for calibration. Here, it indicates which symbols are not dynamic.
+        """
+        maybe_lag_variables = set()
+
+        for sym in reversed(self.dynamics):
+            maybe_lag_variables.discard(sym)  # not a lag if updated dynamically now.
+            rule = self.dynamics[sym]
+            dependencies = extract_dependencies(rule)
+            maybe_lag_variables.update(dependencies)
+
+        for sym in self.shocks:
+            # shocks aren't lag variables
+            maybe_lag_variables.discard(sym)
+
+        if calibration is not None:
+            # these variables are parameters not states
+            for sym in calibration:
+                maybe_lag_variables.discard(sym)
+
+        return maybe_lag_variables
 
 
 @dataclass
@@ -428,8 +465,10 @@ class DBlock(Block):
         rvals = {}
 
         for sym in self.reward:
-            feq = self.dynamics[sym]
-            rvals[sym] = feq(*[vals[var] for var in signature(feq).parameters])
+            update_fn = self.dynamics[sym]
+            rvals[sym] = update_fn(
+                *[vals[var] for var in signature(update_fn).parameters]
+            )
 
         return rvals
 

--- a/src/skagent/rule.py
+++ b/src/skagent/rule.py
@@ -17,7 +17,6 @@ Key functions:
 """
 
 import inspect
-from skagent.model import Control
 from skagent.distributions import Distribution
 from sympy.parsing.sympy_parser import parse_expr
 
@@ -62,6 +61,8 @@ def extract_dependencies(rule):
     list
         List of dependency variable names
     """
+    from skagent.model import Control  # TODO: move to separate module
+
     deps = []
 
     if isinstance(rule, Control):
@@ -107,6 +108,8 @@ def extract_formula(rule):
     str
         The formula as string
     """
+    from skagent.model import Control
+
     if isinstance(rule, Control):
         deps = ", ".join(sorted(rule.iset))
         return f"Control({deps})"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -103,6 +103,23 @@ class test_DBlock(unittest.TestCase):
 
         av({"k": 1, "R": 1.05, "PermGroFac": 1.1, "theta": 1, "CRRA": 2})
 
+    def test_arrival_states(self):
+        a_calibration = {"CRRA", "PermGroFac", "Rfree"}
+        a_arrival_states = self.test_block_A.get_arrival_states(
+            calibration=a_calibration
+        )
+
+        self.assertFalse("CRRA" in a_arrival_states)
+        self.assertFalse("m" in a_arrival_states)
+        self.assertTrue("p" in a_arrival_states)
+
+        c_calibration = {"R", "CRRA", "PermGroFac"}
+        c_arrival_states = self.cblock.get_arrival_states(calibration=c_calibration)
+        self.assertFalse("CRRA" in c_arrival_states)
+        self.assertFalse("theta" in c_arrival_states)
+        self.assertFalse("m" in c_arrival_states)
+        self.assertTrue("k" in c_arrival_states)
+
     def test_attributions(self):
         block_a_attributions = self.test_block_A.get_attributions()
 


### PR DESCRIPTION
This PR adds a method to the Block superclass which computes which variables are 'arrival states' or equivalently 'lag variables' -- meaning, implicitly, which variables from the 'previous period' are needed to compute the dynamics forward.

These 'arrival states' need not be the same as the information set of controls. For example, in our model normalized consumption block, the information set is `m`,  but the arrival state is `k`. 

Detecting these involves looking at all the variables that are required to compute the dynamics forward, and removing those that are: (a) dynamically updated themselves _prior_ to their being used, (b) shock variables, or (c) given in calibration parameters.

Automated tests are include in the PR.

Some minor refactoring/labeling made it into this PR also.