### PR TITLE
BlockPolicyValueNet and general NN training

### DIFF
--- a/src/skagent/algos/maliar.py
+++ b/src/skagent/algos/maliar.py
@@ -366,7 +366,7 @@ def maliar_training_loop(
 def estimate_bellman_residual(
     block,
     discount_factor,
-    value_network,
+    value_function,
     df,
     states_t,
     shocks,
@@ -386,7 +386,7 @@ def estimate_bellman_residual(
         The model block containing dynamics, rewards, and shocks
     discount_factor : float
         The discount factor β
-    value_network : callable
+    value_function : callable
         A value function that takes state variables and returns value estimates
     df : callable
         Decision function that returns controls given states and shocks
@@ -431,7 +431,7 @@ def estimate_bellman_residual(
     reward_sym = reward_vars[0]  # Assume single reward for now
 
     # Get current value estimates (using period t shocks)
-    current_values = value_network(states_t, shocks_t, parameters)
+    current_values = value_function(states_t, shocks_t, parameters)
 
     # Get controls from decision function (using period t shocks)
     controls_t = df(states_t, shocks_t, parameters)
@@ -447,7 +447,7 @@ def estimate_bellman_residual(
     next_states = tf(states_t, shocks_t, controls_t, parameters)
 
     # Compute continuation value using value network (using period t+1 shocks)
-    continuation_values = value_network(next_states, shocks_t_plus_1, parameters)
+    continuation_values = value_function(next_states, shocks_t_plus_1, parameters)
 
     # Bellman equation: V(s) = u(s,c,ε) + β E_ε'[V(s')]
     bellman_rhs = immediate_reward + discount_factor * continuation_values

--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -582,6 +582,9 @@ class BlockPolicyValueNet(Net):
         """
         Initialize the BlockPolicyValueNet.
         """
+        # This network isn't used for anything, because really this wraps two other networks?
+        super().__init__(n_inputs=0, n_outputs=0)  # Call this FIRST
+        # we will overwrite forward() to use the other two networks as well
 
         self.policy_network = BlockPolicyNet(
             block,

--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -257,15 +257,9 @@ class BlockPolicyNet(Net):
         The symbol for the control variable.
     width : int, optional
         Width of hidden layers. Default is 32.
-    n_layers : int, optional
-        Number of hidden layers (1-10). Default is 2.
-    activation : str, list, callable, or None, optional
-        Activation function(s). See Net documentation for details. Default is 'silu'.
-    transform : str, list, callable, or None, optional
-        Output transformation. See Net documentation for details. Default is None.
     **kwargs
         Additional keyword arguments passed to Net. See Net class
-        documentation for all available options including init_seed, copy_weights_from, etc.
+        documentation for all available options including activation, transform, n_layers, init_seed, copy_weights_from, etc.
     """
 
     def __init__(
@@ -465,13 +459,9 @@ class BlockValueNet(Net):
         Number of hidden layers (1-10). Default is 2.
     control_sym : string
         Control variable symbol.
-    activation : str, list, callable, or None, optional
-        Activation function(s). See Net documentation for details. Default is 'silu'.
-    transform : str, list, callable, or None, optional
-        Output transformation. See Net documentation for details. Default is None.
     **kwargs
         Additional keyword arguments passed to Net. See Net class
-        documentation for all available options including init_seed, copy_weights_from, etc.
+        documentation for all available options including activation, transform, init_seed, copy_weights_from, etc.
     """
 
     def __init__(self, block, control_sym=None, width: int = 32, **kwargs):

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -735,30 +735,18 @@ class test_ann_value_functions(unittest.TestCase):
         # The main point is that BlockValueNet works with perfect foresight models
         # This mirrors the policy test pattern of basic smoke testing
 
-    def test_joint_training_comprehensive(self):
+    def test_BlockPolicyValueNet(self):
         """Test comprehensive joint training that mirrors policy training patterns."""
-        # Test that joint training function exists and has correct signature
-        self.assertTrue(hasattr(ann, "train_block_value_and_policy_nn"))
-        self.assertTrue(callable(ann.train_block_value_and_policy_nn))
 
         # Create networks
-        policy_net = ann.BlockPolicyNet(self.test_block, width=8)
-        value_net = ann.BlockValueNet(self.test_block, width=8)
+        policy_value_net = ann.BlockPolicyValueNet(self.test_block)
 
-        # Test that networks can make predictions before training
-        policy_decisions = policy_net.decision_function(
-            {"wealth": torch.tensor([2.0])}, {"income": torch.tensor([1.0])}, {}
-        )
-        self.assertIn("consumption", policy_decisions)
-        self.assertIsInstance(policy_decisions["consumption"], torch.Tensor)
+        drs, vf = policy_value_net.get_policy_and_value_functions(10)
+
+        self.assertIn("consumption", drs)
 
         # Test value network predictions
         test_states = {"wealth": torch.tensor([2.0])}
-        value_estimates = value_net.value_function(
-            test_states, {"income": torch.tensor([1.0])}, {}
-        )
+        value_estimates = vf(test_states, {"income": torch.tensor([1.0])}, {})
         self.assertIsInstance(value_estimates, torch.Tensor)
         self.assertEqual(value_estimates.shape, (1,))
-
-        # This demonstrates that the joint training infrastructure exists
-        # The actual training is tested in the individual components

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -590,41 +590,6 @@ class test_ann_value_functions(unittest.TestCase):
         # Both functions take a DBlock and produce loss functions - this is the key objective
         # They represent different forms: lifetime reward vs Bellman equation
 
-    def test_joint_training_function_exists(self):
-        """Test that joint training function exists and is consistent."""
-        # Test that the joint training function exists
-        self.assertTrue(hasattr(ann, "train_block_value_and_policy_nn"))
-        self.assertTrue(callable(ann.train_block_value_and_policy_nn))
-
-        # The function follows the same pattern as individual training functions
-        # Signature: train_block_value_and_policy_nn(policy_net, value_net, inputs, policy_loss, value_loss, epochs)
-
-        # This enables value function iteration algorithms that need both policy and value updates
-
-    def test_joint_training_integration(self):
-        """Test joint training integration with Bellman loss functions."""
-        # This demonstrates how to use the joint training function with Bellman losses
-
-        # Step 1: Create networks
-        ann.BlockPolicyNet(self.test_block, width=8)
-        value_net = ann.BlockValueNet(self.test_block, width=8)
-
-        # Step 2: Create Bellman loss function
-        maliar.get_bellman_equation_loss(
-            self.state_variables,
-            self.test_block,
-            self.discount_factor,
-            value_net.get_value_function(),
-            self.parameters,
-        )
-
-        # Step 3: Test that joint training can be used with the loss function
-        # (Just verify the interface exists - actual training would require careful setup)
-        self.assertTrue(callable(ann.train_block_value_and_policy_nn))
-
-        # The pattern is: create networks, create loss functions, then train jointly
-        # train_block_value_and_policy_nn(policy_net, value_net, inputs, policy_loss, value_loss, epochs)
-
     def test_value_function_case_scenarios(self):
         """Test value function training with the same case scenarios used for policy testing."""
         # Test value function training with case_0 scenario

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -52,7 +52,7 @@ class test_ann_lr(unittest.TestCase):
         states_0_N = case_0["givens"]
 
         bpn = ann.BlockPolicyNet(case_0["block"], width=16)
-        ann.train_block_policy_nn(bpn, states_0_N, edlrl, epochs=250)
+        ann.train_block_nn(bpn, states_0_N, edlrl, epochs=250)
 
         c_ann = bpn.decision_function(states_0_N.to_dict(), {}, {})["c"]
 
@@ -73,7 +73,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_1["givens"][1]
 
         bpn = ann.BlockPolicyNet(case_1["block"], width=16)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=500)
+        ann.train_block_nn(bpn, given_0_N, edlrl, epochs=500)
 
         c_ann = bpn.decision_function(
             # TODO -- make this from the Grid
@@ -104,7 +104,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_1["givens"][2]
 
         bpn = ann.BlockPolicyNet(case_1["block"], width=16)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=500)
+        ann.train_block_nn(bpn, given_0_N, edlrl, epochs=500)
 
         c_ann = bpn.decision_function(
             {"a": given_0_N["a"]},
@@ -131,7 +131,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_2["givens"]
 
         bpn = ann.BlockPolicyNet(case_2["block"], width=8)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=100)
+        ann.train_block_nn(bpn, given_0_N, edlrl, epochs=100)
 
         # optimal DR is c = 0 = E[theta]
 
@@ -155,7 +155,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_3["givens"][1]
 
         bpn = ann.BlockPolicyNet(case_3["block"], width=8)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+        ann.train_block_nn(bpn, given_0_N, edlrl, epochs=300)
 
         c_ann = bpn.decision_function(
             {"a": given_0_N["a"]},
@@ -181,7 +181,7 @@ class test_ann_lr(unittest.TestCase):
         given_0_N = case_3["givens"][2]
 
         bpn = ann.BlockPolicyNet(case_3["block"], width=8)
-        ann.train_block_policy_nn(bpn, given_0_N, edlrl, epochs=300)
+        ann.train_block_nn(bpn, given_0_N, edlrl, epochs=300)
 
         c_ann = bpn.decision_function(
             {"a": given_0_N["a"]},
@@ -645,7 +645,7 @@ class test_ann_value_functions(unittest.TestCase):
             return (values - target_values) ** 2
 
         # Test training (short epochs for testing)
-        trained_value_net = ann.train_block_value_nn(
+        trained_value_net = ann.train_block_nn(
             value_net, case_0["givens"], zero_target_value_loss, epochs=10
         )
 
@@ -723,7 +723,7 @@ class test_ann_value_functions(unittest.TestCase):
         )
 
         # Train with more epochs for convergence
-        trained_net = ann.train_block_value_nn(
+        trained_net = ann.train_block_nn(
             value_net, test_grid, linear_target_loss, epochs=200
         )
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+import torch
 
 from skagent.distributions import (
     Bernoulli,
@@ -22,9 +23,18 @@ from skagent.distributions import (
     expected,
 )
 
+# Deterministic test seed - change this single value to modify all seeding
+# Using same seed as test_maliar.py for consistency across test suite
+TEST_SEED = 10077693
+
 
 class TestDistributions(unittest.TestCase):
     """Test cases for the distribution classes that replace HARK distributions"""
+
+    def setUp(self):
+        # Set deterministic state for each test (avoid global state interference in parallel runs)
+        torch.manual_seed(TEST_SEED)
+        np.random.seed(TEST_SEED)
 
     def test_normal_scipy(self):
         """Test Normal distribution with scipy backend"""
@@ -131,9 +141,9 @@ class TestDistributions(unittest.TestCase):
     def test_uniform_custom_range(self):
         """Test Uniform distribution with custom range"""
         u = Uniform(-2, 3, backend="scipy")
-        samples = u.draw(1000)
+        samples = u.draw(10000)
 
-        assert len(samples) == 1000
+        assert len(samples) == 10000
         assert all(-2 <= s <= 3 for s in samples)  # All samples should be in [-2, 3]
         # Mean should be close to 0.5
         assert np.isclose(np.mean(samples), 0.5, atol=0.1)


### PR DESCRIPTION
This PR addresses #114 .

- BlockPolicyNet and BlockValueNet each now have a `get_core_function` method.
- This allows consolidation of `train_block_nn` which generalizes over the two
- There's a BlockPolicyValueNet that wraps both other kinds of Block*Nets

Remaining to do:
- Demonstrate that the BlockPolicyValueNet can be trained using the same `train_block_nn` loop, using a sensible loss function
- That might mean rewrapping the Bellman loss function to work here, but that is touched by #109 

There's an underlying issue that's causing some messiness:
- the original BlockPolicyNet and the Value/Bellman stuff that came after it assumes one control variable, so 'decision_function' is well-defined
- for solving (sequentially) multiple control variables, we need to hold some decision rules constant while letting others vary. So the BlockPolicyNet can also emit decision rules. The BlockPolicyValueNet now emits as a core function something of mixed types, which is not ideal