### PR TITLE
refactor: BellmanPeriod and Euler/Bellman residual framework

### DIFF
--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -340,8 +340,9 @@ class BlockPolicyNet(BellmanPeriodMixin, Net):
 
     def decision_function(self, states_t, shocks_t, parameters):
         """
-        A decision function, from states, shocks, and parameters,
-        to control variable values.
+        A decision function, from arrival states, shocks, and parameters,
+        to control variable values. Accepts inputs that already contain
+        the control's iset (no transition is run in that case).
 
         Parameters
         ----------
@@ -361,21 +362,12 @@ class BlockPolicyNet(BellmanPeriodMixin, Net):
         decisions - dict
             symbols : values
         """
-        if parameters is None:
-            parameters = {}
-        vals = parameters | states_t | shocks_t
-
-        # hacky -- should be moved into transition method as other option
-        # very brittle, because it can interfere with constraints
-        drs = {
-            control_sym: lambda: 1 for control_sym in self.bellman_period.get_controls()
-        }
-
-        post = self.bellman_period.block.transition(vals, drs, until=self.control_sym)
-
+        iset_dict = self.bellman_period.compute_pre_state(
+            self.control_sym, states_t, shocks=shocks_t, parameters=parameters
+        )
         # the inputs to the network are the information set of the control variable
         # The use of torch.stack and .T here are wild guesses, probably doesn't generalize
-        iset_vals = [post[isym].flatten() for isym in self.iset]
+        iset_vals = [iset_dict[isym].flatten() for isym in self.iset]
 
         def get_tensor_size(d):
             for value in d.values():
@@ -385,11 +377,9 @@ class BlockPolicyNet(BellmanPeriodMixin, Net):
                     return value.size
             return 1  # No tensors found
 
-        print(post.values())
-
-        output = self.get_decision_rule(length=get_tensor_size(post))[self.control_sym](
-            *iset_vals
-        )
+        output = self.get_decision_rule(length=get_tensor_size(iset_dict))[
+            self.control_sym
+        ](*iset_vals)
 
         # again, assuming only one for now...
         # decisions = dict(zip([control_sym], output))
@@ -520,29 +510,29 @@ class BlockValueNet(BellmanPeriodMixin, Net):
 
     def value_function(self, states_t, shocks_t={}, parameters={}):
         """
-        Compute value function estimates for given state variables.
-
-        The value function takes the same information as the policy function
-        (the control's information set) but doesn't need to compute transitions.
+        Compute value function estimates from arrival states. Accepts
+        inputs that already contain the control's iset (no transition
+        is run in that case).
 
         Parameters
         ----------
         states_t : dict
-            State variables as dict (e.g., {"wealth": tensor(...)})
+            Arrival state variables (or, equivalently, a dict already
+            containing the control's iset variables).
         shocks_t : dict, optional
-            Shock variables as dict (not used but kept for interface consistency)
+            Shock realizations for the period.
         parameters : dict, optional
-            Model parameters (not used but kept for interface consistency)
+            Model parameters.
 
         Returns
         -------
         torch.Tensor
-            Value function estimates
+            Value function estimates.
         """
-        # The inputs to the network are the information set variables
-        # Combine states_t and shocks_t to get all available variables
-        all_vars = states_t | shocks_t
-        iset_vals = [all_vars[isym].flatten() for isym in self.cobj.iset]
+        iset_dict = self.bellman_period.compute_pre_state(
+            self.control_sym, states_t, shocks=shocks_t, parameters=parameters
+        )
+        iset_vals = [iset_dict[isym].flatten() for isym in self.cobj.iset]
 
         input_tensor = torch.stack(iset_vals).T
 

--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -340,9 +340,8 @@ class BlockPolicyNet(BellmanPeriodMixin, Net):
 
     def decision_function(self, states_t, shocks_t, parameters):
         """
-        A decision function, from arrival states, shocks, and parameters,
-        to control variable values. Accepts inputs that already contain
-        the control's iset (no transition is run in that case).
+        A decision function, from states, shocks, and parameters,
+        to control variable values.
 
         Parameters
         ----------
@@ -510,24 +509,24 @@ class BlockValueNet(BellmanPeriodMixin, Net):
 
     def value_function(self, states_t, shocks_t={}, parameters={}):
         """
-        Compute value function estimates from arrival states. Accepts
-        inputs that already contain the control's iset (no transition
-        is run in that case).
+        Compute value function estimates for given state variables.
+
+        The value function takes the same information as the policy function
+        (the control's information set) but doesn't need to compute transitions.
 
         Parameters
         ----------
         states_t : dict
-            Arrival state variables (or, equivalently, a dict already
-            containing the control's iset variables).
+            State variables as dict (e.g., {"wealth": tensor(...)})
         shocks_t : dict, optional
-            Shock realizations for the period.
+            Shock variables as dict (not used but kept for interface consistency)
         parameters : dict, optional
-            Model parameters.
+            Model parameters (not used but kept for interface consistency)
 
         Returns
         -------
         torch.Tensor
-            Value function estimates.
+            Value function estimates
         """
         iset_dict = self.bellman_period.compute_pre_state(
             self.control_sym, states_t, shocks=shocks_t, parameters=parameters

--- a/src/skagent/bellman.py
+++ b/src/skagent/bellman.py
@@ -11,6 +11,7 @@ and framing them in terms of arrival states, shocks, and decisions.
 from __future__ import annotations
 
 import inspect
+import logging
 from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
@@ -148,6 +149,61 @@ class BellmanPeriod:
             If no reward variables match the given agent.
         """
         return self.get_reward_syms(agent)[0]
+
+    def compute_pre_decision_state(
+        self,
+        states: dict[str, Any],
+        *,
+        shocks: dict[str, Any] | None = None,
+        parameters: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Compute the pre-decision state from arrival states and shocks.
+
+        If the control's information set variables (e.g. cash-on-hand ``m``)
+        are not already present in *states*, runs block dynamics from arrival
+        states up to the control to produce them. If they are already present
+        (the control operates directly on arrival states), returns the merged
+        inputs unchanged.
+
+        Parameters
+        ----------
+        states : dict[str, Any]
+            Arrival state variables (e.g., ``{"a": tensor}``).
+        shocks : dict[str, Any] | None, optional
+            Current shock realizations (defaults to empty dict).
+        parameters : dict[str, Any] | None, optional
+            Model parameters (defaults to instance calibration).
+
+        Returns
+        -------
+        dict[str, Any]
+            Merged dict of parameters, arrival states, shocks, and any
+            computed pre-decision variables.
+        """
+        shocks = self._resolve_shocks(shocks)
+        params = self._resolve_parameters(parameters)
+        collision = set(params) & set(states)
+        if collision:
+            raise ValueError(
+                f"compute_pre_decision_state: parameter keys conflict with state keys: "
+                f"{sorted(collision)}. Rename either the parameters or the state "
+                "variables to avoid shadowing."
+            )
+        vals = params | states | shocks
+
+        control_sym = next(iter(self.get_controls()))
+        iset = self.block.dynamics[control_sym].iset
+
+        # If the control's iset variables are already available, no
+        # pre-decision computation needed (control operates directly
+        # on arrival states).
+        if all(isym in vals for isym in iset):
+            return vals
+
+        # Compute pre-decision dynamics (e.g. m = R*a/ψ + 1 for U-2)
+        drs = {cs: (lambda: 1) for cs in self.get_controls()}
+        post = self.block.transition(vals, drs, until=control_sym)
+        return post
 
     def compute_controls(
         self,
@@ -412,7 +468,7 @@ class BellmanPeriod:
         # Filter rewards by agent
         rewards = {sym: post[sym] for sym in self.get_reward_syms(agent)}
 
-        # Use utility function to compute gradients
+        # Compute gradients of reward w.r.t. requested variables
         return compute_gradients_for_tensors(rewards, wrt, create_graph=create_graph)
 
     def grad_transition_function(
@@ -468,7 +524,7 @@ class BellmanPeriod:
             decision_rules=decision_rules,
         )
 
-        # Use utility function to compute gradients
+        # Compute gradients of next-state outputs w.r.t. requested variables
         return compute_gradients_for_tensors(
             next_states, wrt, create_graph=create_graph
         )
@@ -556,7 +612,7 @@ class BellmanPeriod:
             pre_state_vars, states, shocks=shocks, parameters=parameters
         )
 
-        # Use utility function to compute gradients
+        # Compute gradients of pre-decision state values w.r.t. requested variables
         return compute_gradients_for_tensors(
             pre_state_values, wrt, create_graph=create_graph
         )
@@ -626,6 +682,74 @@ class BellmanPeriod:
                 )
 
         return pre_state_values
+
+    def resolve_discount_factor(self, post: dict[str, Any]) -> Any:
+        """Extract the discount factor from post-transition variables.
+
+        Parameters
+        ----------
+        post : dict[str, Any]
+            Output of :meth:`post_function`.
+
+        Returns
+        -------
+        Any
+            The discount factor value.
+
+        Raises
+        ------
+        KeyError
+            If :attr:`discount_variable` is not present in *post*.
+        """
+        dv = self.discount_variable
+        if dv not in post:
+            raise KeyError(
+                f"Discount variable '{dv}' not found in post-transition output. "
+                f"Available variables: {sorted(post.keys())}. "
+                "Ensure the discount variable is defined in block.dynamics "
+                "or passed in calibration."
+            )
+        return post[dv]
+
+
+def fischer_burmeister(
+    a: torch.Tensor, h: torch.Tensor, eps: float = 1e-12
+) -> torch.Tensor:
+    r"""Compute the Fischer-Burmeister function for smooth complementarity.
+
+    The Fischer-Burmeister function replaces the complementarity conditions
+    :math:`a \geq 0,\; h \geq 0,\; ah = 0` with the equivalent smooth equation:
+
+    .. math::
+
+        \text{FB}(a, h) = a + h - \sqrt{a^2 + h^2} = 0
+
+    This is differentiable everywhere, unlike :math:`\min(a, h) = 0`.
+
+    Following Maliar et al. (2021, JME) equation (25).
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        First argument (e.g., slack variable :math:`1 - c/w`).
+    h : torch.Tensor
+        Second argument (e.g., unit-free Lagrange multiplier).
+    eps : float, optional
+        Regularization constant added inside the square root to keep the
+        gradient finite at the origin. At the default ``eps=1e-12``,
+        ``FB(0, 0) = -sqrt(eps) ≈ -1e-6`` rather than exactly zero.
+        This is below typical convergence tolerances but should be
+        accounted for in tests or with very tight tolerances.
+
+    Returns
+    -------
+    torch.Tensor
+        Fischer-Burmeister residual. Approximately zero when the
+        complementarity conditions are satisfied.
+    """
+    if eps <= 0:
+        raise ValueError(f"eps must be > 0, got {eps}")
+    return a + h - torch.sqrt(a**2 + h**2 + eps)
 
 
 def _extract_period_shocks(
@@ -759,15 +883,7 @@ def estimate_discounted_lifetime_reward(
         post = bellman_period.post_function(
             states_t, controls_t, shocks=shocks_t, parameters=parameters, agent=agent
         )
-        if bellman_period.discount_variable not in post:
-            raise KeyError(
-                f"Discount variable '{bellman_period.discount_variable}' not found "
-                f"in post-transition output. "
-                f"Available variables: {sorted(post.keys())}. "
-                "Ensure the discount variable is defined in block.dynamics "
-                "or passed in calibration."
-            )
-        discount_factor = post[bellman_period.discount_variable]
+        discount_factor = bellman_period.resolve_discount_factor(post)
 
         reward_t = bellman_period.reward_function(
             states_t, controls_t, shocks=shocks_t, parameters=parameters, agent=agent
@@ -863,8 +979,15 @@ def estimate_bellman_residual(
     # value_function is an external callable that may not handle None
     params_ext = parameters if parameters is not None else {}
 
-    # Get current value estimates (using period t shocks)
-    current_values = value_function(states_t, shocks_t, params_ext)
+    # Compute pre-decision state from arrival states + shocks so that
+    # the value function sees the variables it expects (e.g. cash-on-hand
+    # m computed from arrival assets a and shocks).
+    pre_decision_t = bellman_period.compute_pre_decision_state(
+        states_t, shocks=shocks_t, parameters=parameters
+    )
+
+    # Get current value estimates (using pre-decision state)
+    current_values = value_function(pre_decision_t, shocks_t, params_ext)
 
     # Get controls from decision function (using period t shocks)
     controls_t = bellman_period.compute_controls(
@@ -881,23 +1004,20 @@ def estimate_bellman_residual(
         states_t, controls_t, shocks=shocks_t, parameters=parameters
     )
 
-    # Compute continuation value using value network (using period t+1 shocks)
-    continuation_values = value_function(next_states, shocks_t_plus_1, params_ext)
+    # Compute pre-decision state for next period (arrival states + next shocks)
+    pre_decision_t1 = bellman_period.compute_pre_decision_state(
+        next_states, shocks=shocks_t_plus_1, parameters=parameters
+    )
+
+    # Compute continuation value using value network (using pre-decision state of t+1)
+    continuation_values = value_function(pre_decision_t1, shocks_t_plus_1, params_ext)
 
     # TODO: this is all calling the forward simulation multiple times;
     #       can be made more efficient
     post = bellman_period.post_function(
         states_t, controls_t, shocks=shocks_t, parameters=parameters
     )
-    if bellman_period.discount_variable not in post:
-        raise KeyError(
-            f"Discount variable '{bellman_period.discount_variable}' not found "
-            f"in post-transition output. "
-            f"Available variables: {sorted(post.keys())}. "
-            "Ensure the discount variable is defined in block.dynamics "
-            "or passed in calibration."
-        )
-    discount_factor = post[bellman_period.discount_variable]
+    discount_factor = bellman_period.resolve_discount_factor(post)
 
     # Bellman equation: V(s) = u(s,c,ε) + β E_ε'[V(s')]
     bellman_rhs = immediate_reward + discount_factor * continuation_values
@@ -905,196 +1025,111 @@ def estimate_bellman_residual(
     # Return residual: V(s) - [u(s,c,ε) + β V(s')]
     bellman_residual = current_values - bellman_rhs
 
+    if torch.any(torch.isnan(bellman_residual)) or torch.any(
+        torch.isinf(bellman_residual)
+    ):
+        # Provide detailed diagnostics to help locate the source
+        def _range_str(t):
+            if not isinstance(t, torch.Tensor):
+                return str(t)
+            return f"[{t.min().item():.2e}, {t.max().item():.2e}]"
+
+        raise ValueError(
+            "Bellman residual contains NaN or Inf. "
+            f"immediate_reward range: {_range_str(immediate_reward)}, "
+            f"discount_factor: {_range_str(discount_factor)}, "
+            f"continuation_values range: {_range_str(continuation_values)}, "
+            f"current_values range: {_range_str(current_values)}."
+        )
+
     return bellman_residual
 
 
-def estimate_euler_residual(
+def _chain_rule_return_factor(
     bellman_period: BellmanPeriod,
-    discount_factor: float,
-    df: dict[str, Callable] | Callable,
-    states_t: dict[str, Any],
-    shocks: dict[str, Any],
-    parameters: dict[str, Any] | None = None,
-    agent: str | None = None,
+    control_sym: str,
+    transition_gradients: dict[str, torch.Tensor | None],
+    pre_state_gradients: dict[str, dict[str, torch.Tensor | None]],
+    like: torch.Tensor,
 ) -> torch.Tensor:
+    r"""Sum the chain-rule product :math:`\sum_s \partial m'/\partial s' \cdot \partial s'/\partial c`.
+
+    Raises ``ValueError`` if no chain-rule path contributes.
     """
-    Computes the Euler equation residual for given states and shocks.
-
-    The Euler equation is the first-order condition from the Bellman equation,
-    relating marginal utilities across periods. This function computes the Euler
-    equation **residual**:
-
-    .. math::
-
-        f = u'(c_t) + \\beta \\cdot u'(c_{t+1}) \\cdot \\sum_s \\left[
-            \\frac{\\partial s_{t+1}}{\\partial c_t} \\cdot \\frac{\\partial m'}{\\partial s_{t+1}}
-        \\right]
-
-    where :math:`f` is the Euler equation residual, :math:`s_{t+1}` is the next-period
-    arrival state, and :math:`m'` is the pre-decision state (information set for the
-    control). At optimality, :math:`f = 0` represents the first-order condition being
-    satisfied.
-
-    **Derivation:**
-
-    The first-order condition from the Bellman equation
-    :math:`V(s) = \\max_c \\{ u(c) + \\beta E[V(s')] \\}` is:
-
-    .. math::
-
-        u'(c_t) = -\\beta E\\left[V'(s_{t+1}) \\cdot \\frac{\\partial s_{t+1}}{\\partial c_t}\\right]
-
-    By the envelope theorem, :math:`V'(s') = u'(c') \\cdot \\frac{\\partial m'}{\\partial s'}`,
-    where :math:`m'` is the pre-decision state. Substituting:
-
-    .. math::
-
-        u'(c_t) = -\\beta E\\left[u'(c_{t+1}) \\cdot \\frac{\\partial m'}{\\partial s_{t+1}}
-            \\cdot \\frac{\\partial s_{t+1}}{\\partial c_t}\\right]
-
-    Rearranging to define the residual :math:`f`:
-
-    .. math::
-
-        f = u'(c_t) + \\beta E\\left[u'(c_{t+1}) \\cdot \\frac{\\partial m'}{\\partial s_{t+1}}
-            \\cdot \\frac{\\partial s_{t+1}}{\\partial c_t}\\right] = 0
-
-    **Example:**
-
-    For a consumption-saving model with :math:`a_{t+1} = m_t - c_t` where
-    :math:`m_t = R \\cdot a_t + y_t` (cash-on-hand):
-
-    - Transition gradient: :math:`\\frac{\\partial a_{t+1}}{\\partial c_t} = -1`
-    - Pre-state gradient: :math:`\\frac{\\partial m'}{\\partial a_{t+1}} = R`
-    - Combined: :math:`\\frac{\\partial m'}{\\partial a_{t+1}} \\cdot \\frac{\\partial a_{t+1}}{\\partial c_t} = R \\cdot (-1) = -R`
-
-    Substituting into the residual:
-
-    .. math::
-
-        f = u'(c_t) + \\beta \\cdot u'(c_{t+1}) \\cdot (-R) = u'(c_t) - \\beta R \\cdot u'(c_{t+1})
-
-    At optimality, :math:`f = 0` gives the standard Euler equation
-    :math:`u'(c_t) = \\beta R E[u'(c_{t+1})]`.
-
-    **Notation:**
-
-    Following Maliar et al. (2021) Definition 2.7, this function computes a single
-    Euler equation residual using two independent shock realizations. The residual
-    :math:`f` uses shocks :math:`\\varepsilon_0` for transitions from :math:`t` to
-    :math:`t+1` and :math:`\\varepsilon_1` for transitions from :math:`t+1` to
-    :math:`t+2`.
-
-    The loss function then computes :math:`L(\\theta) = E[f^2]` where the squared
-    residual approximates the squared expectation operator from the paper.
-
-    Note: We use :math:`\\varepsilon` (epsilon) to denote exogenous shocks, which may
-    differ slightly from Maliar et al.'s notation but represents the same concept of
-    stochastic disturbances in the model.
-
-    **Limitations:**
-
-    Currently only supports single-control models. Multi-control models will raise
-    NotImplementedError.
-
-    Parameters
-    ----------
-    bellman_period : BellmanPeriod
-        The Bellman period with transitions, rewards, etc.
-    discount_factor : float
-        The discount factor β (time preference parameter). Must be numerical
-        (state-dependent discount factors are not yet supported).
-    df : dict[str, Callable] | Callable
-        Decision function that returns controls given states and shocks.
-        Can be a callable with signature df(states_t, shocks_t, parameters) -> controls_t
-        or a dict of decision rules.
-    states_t : dict[str, Any]
-        Current state variables (arrival states).
-    shocks : dict[str, Any]
-        Shock realizations for both periods:
-        - {shock_sym}_0: period t shocks (for transitions to t+1)
-        - {shock_sym}_1: period t+1 shocks (for transitions to t+2)
-        This structure supports the AiO expectation operator.
-    parameters : dict[str, Any] | None, optional
-        Model parameters for calibration (defaults to empty dict).
-    agent : str | None, optional
-        Agent identifier for rewards.
-
-    Returns
-    -------
-    torch.Tensor
-        Euler equation residual computed using two independent shock realizations
-        (one for each period transition). Returns one residual value per state sample.
-
-    Raises
-    ------
-    ValueError
-        If discount_factor is callable, no control or reward variables found,
-        or marginal utility cannot be computed.
-    NotImplementedError
-        If the model has multiple control variables.
-    KeyError
-        If required shock variables are missing from the shocks dict.
-
-    Notes
-    -----
-    This implementation follows Maliar, Maliar, and Winant (2021, JME) Section 2.2.
-    The AiO expectation operator (Definition 2.7) requires two independent shock
-    realizations to approximate the squared expectation E[(E[f])²].
-
-    Examples
-    --------
-    >>> # Euler equation automatically adapts to your model's reward structure
-    >>> residual = estimate_euler_residual(
-    ...     bp, 0.95, my_policy, states_t, shocks, parameters
-    ... )
-    """
-    if callable(discount_factor):
+    if torch.any(torch.isnan(like)) or torch.any(torch.isinf(like)):
         raise ValueError(
-            "State-dependent discount factors not yet supported for Euler residuals. "
-            "Please pass a numerical discount factor."
+            f"Euler residual: marginal_reward_t1 contains NaN or Inf for "
+            f"control '{control_sym}'. Cannot compute chain-rule return factor."
         )
 
-    shocks_t, shocks_t_plus_1 = _extract_period_shocks(bellman_period, shocks)
+    total = torch.zeros_like(like)
 
-    reward_sym = bellman_period.get_reward_sym(agent)
+    for state_sym in bellman_period.arrival_states:
+        trans_grad = transition_gradients[state_sym]
+        if trans_grad is None:
+            logging.debug(
+                "Transition gradient d(%s)/d(%s) is None (no computational path). "
+                "If unexpected, check that control '%s' tensors require_grad.",
+                state_sym,
+                control_sym,
+                control_sym,
+            )
+            continue
+        for state_grads in pre_state_gradients.values():
+            pre_state_grad = state_grads.get(state_sym)
+            if pre_state_grad is not None:
+                total = total + pre_state_grad * trans_grad
 
-    # Get controls from decision function for period t
-    controls_t = bellman_period.compute_controls(
-        df, states_t, shocks=shocks_t, parameters=parameters
-    )
-
-    # Compute next period states (t+1) using first shock realization
-    states_t_plus_1 = bellman_period.transition_function(
-        states_t, controls_t, shocks=shocks_t, parameters=parameters
-    )
-
-    # Get controls for period t+1 using second independent shock realization
-    controls_t_plus_1 = bellman_period.compute_controls(
-        df, states_t_plus_1, shocks=shocks_t_plus_1, parameters=parameters
-    )
-
-    # Get control symbols to compute gradients with respect to
-    control_syms = list(controls_t)
-    if len(control_syms) == 0:
-        raise ValueError("No control variables found in decision function")
-    if len(control_syms) > 1:
-        raise NotImplementedError(
-            "Euler residual estimation currently only supports single-control models. "
-            f"Found controls: {control_syms}"
+    if torch.any(torch.isnan(total)):
+        raise ValueError(
+            f"Euler residual: return_factor_sum contains NaN for "
+            f"control '{control_sym}'. This indicates ill-conditioned "
+            "transition or pre-state gradients. Check block dynamics for "
+            "numerical stability."
         )
+    if torch.any(torch.isinf(total)):
+        raise ValueError(
+            f"Euler residual: return_factor_sum contains Inf for "
+            f"control '{control_sym}'. This indicates ill-conditioned "
+            "transition or pre-state gradients. Check block dynamics for "
+            "numerical stability."
+        )
+    if not torch.any(total != 0):
+        raise ValueError(
+            "Euler residual: return_factor_sum is zero for all arrival states. "
+            "No arrival state depends on the control through the transition "
+            "and pre-state gradients. Check that the block dynamics correctly "
+            f"connect the control '{control_sym}' to the arrival states "
+            f"{sorted(bellman_period.arrival_states)} and that the Control "
+            "object has a properly defined 'iset'."
+        )
+    return total
 
-    control_sym = control_syms[0]
 
-    # Ensure requires_grad on control tensors for gradient computation.
-    # Detach and reattach if the policy network didn't set requires_grad.
+def _euler_residual_single_control(
+    bellman_period: BellmanPeriod,
+    discount_factor: Any,
+    control_sym: str,
+    reward_sym: str,
+    states_t: dict[str, Any],
+    controls_t: dict[str, Any],
+    states_t_plus_1: dict[str, Any],
+    controls_t_plus_1: dict[str, Any],
+    shocks_t: dict[str, Any],
+    shocks_t_plus_1: dict[str, Any],
+    parameters: dict[str, Any] | None,
+    agent: str | None,
+) -> torch.Tensor:
+    """Compute the Euler residual for a single control variable.
+
+    This is the inner workhorse called once per control by
+    ``estimate_euler_residual``.  Factored out to support multi-control models.
+    """
     c_t, controls_t_grad = _ensure_grad(controls_t, control_sym)
     c_t1, controls_t1_grad = _ensure_grad(controls_t_plus_1, control_sym)
 
-    # Marginal utilities at t and t+1 via grad_reward_function.
-    # create_graph=True keeps the policy network in the computation graph
-    # for end-to-end training.
-    reward_grads_t = bellman_period.grad_reward_function(
+    # ∂u/∂c at period t
+    grads_t = bellman_period.grad_reward_function(
         states_t,
         controls_t_grad,
         wrt={control_sym: c_t},
@@ -1103,14 +1138,15 @@ def estimate_euler_residual(
         agent=agent,
         create_graph=True,
     )
-    marginal_utility_t = reward_grads_t[reward_sym][control_sym]
-    if marginal_utility_t is None:
+    marginal_reward_t = grads_t[reward_sym][control_sym]
+    if marginal_reward_t is None:
         raise ValueError(
-            f"Could not compute marginal utility at period t: "
+            f"Could not compute marginal reward at period t: "
             f"reward '{reward_sym}' does not depend on control '{control_sym}'"
         )
 
-    reward_grads_t1 = bellman_period.grad_reward_function(
+    # ∂u/∂c at period t+1
+    grads_t1 = bellman_period.grad_reward_function(
         states_t_plus_1,
         controls_t1_grad,
         wrt={control_sym: c_t1},
@@ -1119,15 +1155,14 @@ def estimate_euler_residual(
         agent=agent,
         create_graph=True,
     )
-    marginal_utility_t_plus_1 = reward_grads_t1[reward_sym][control_sym]
-    if marginal_utility_t_plus_1 is None:
+    marginal_reward_t1 = grads_t1[reward_sym][control_sym]
+    if marginal_reward_t1 is None:
         raise ValueError(
-            f"Could not compute marginal utility at period t+1: "
+            f"Could not compute marginal reward at period t+1: "
             f"reward '{reward_sym}' does not depend on control '{control_sym}'"
         )
 
     # Transition gradients: ∂s_{t+1}/∂c_t for all arrival states.
-    # This captures how today's control affects tomorrow's state (e.g., ∂a'/∂c = -1).
     trans_grads_nested = bellman_period.grad_transition_function(
         states_t,
         controls_t_grad,
@@ -1141,63 +1176,269 @@ def estimate_euler_residual(
         for state_sym in bellman_period.arrival_states
     }
 
-    # Pre-state gradients: ∂m'/∂s' (how pre-state depends on arrival state).
-    # By the envelope theorem: V'(s') = u'(c') * ∂m'/∂s'.
-    # For consumption-saving with m = a*R + y, this gives ∂m/∂a = R.
-    #
-    # Make arrival states at t+1 require gradients for differentiation.
-    states_t_plus_1_grad = {}
-    for sym in bellman_period.arrival_states:
-        s = states_t_plus_1[sym]
-        if not s.requires_grad:
-            s = s.detach().requires_grad_(True)
-        states_t_plus_1_grad[sym] = s
+    # Pre-state gradients: ∂m'/∂s' (envelope condition).
+    states_t1_grad = {
+        sym: s if s.requires_grad else s.detach().requires_grad_(True)
+        for sym, s in states_t_plus_1.items()
+        if sym in bellman_period.arrival_states
+    }
 
     pre_state_gradients = bellman_period.grad_pre_state_function(
-        states_t_plus_1_grad,
-        wrt=states_t_plus_1_grad,
+        states_t1_grad,
+        wrt=states_t1_grad,
         shocks=shocks_t_plus_1,
         parameters=parameters,
         control_sym=control_sym,
         create_graph=True,
     )
 
-    # Chain rule: ∂m'/∂c = Σ_s [∂m'/∂s' * ∂s'/∂c]
-    # This gives the total derivative of pre-state w.r.t. control through all paths
-    return_factor_sum = torch.zeros_like(marginal_utility_t_plus_1)
-
-    for state_sym in bellman_period.arrival_states:
-        trans_grad = transition_gradients[state_sym]
-        if trans_grad is None:
-            continue
-
-        for _pre_state_var, state_grads in pre_state_gradients.items():
-            pre_state_grad = state_grads.get(state_sym)
-            if pre_state_grad is not None:
-                return_factor_sum = return_factor_sum + pre_state_grad * trans_grad
-
-    # Verify that at least one chain-rule path contributed
-    if not torch.any(return_factor_sum != 0):
-        raise ValueError(
-            "Euler residual: return_factor_sum is zero for all arrival states. "
-            "No arrival state depends on the control through the transition "
-            "and pre-state gradients. Check that the block dynamics correctly "
-            f"connect the control '{control_sym}' to the arrival states "
-            f"{sorted(bellman_period.arrival_states)} and that the Control "
-            "object has a properly defined 'iset'."
-        )
-
-    # Euler equation residual.
-    # FOC: u'(c_t) = -β * Σ_s [V'(s') * ∂s'/∂c_t]
-    # Envelope: V'(s') = u'(c') * ∂m'/∂s'
-    # Residual: f = u'(c_t) + β * u'(c_{t+1}) * Σ_s [∂m'/∂s' * ∂s'/∂c] = 0
-    #
-    # For consumption-saving: ∂a'/∂c = -1, ∂m'/∂a' = R
-    # So: f = u'(c) + β * u'(c') * (-R) = u'(c) - βR*u'(c')
-
-    euler_residual = (
-        marginal_utility_t
-        + discount_factor * marginal_utility_t_plus_1 * return_factor_sum
+    return_factor = _chain_rule_return_factor(
+        bellman_period,
+        control_sym,
+        transition_gradients,
+        pre_state_gradients,
+        like=marginal_reward_t1,
     )
 
-    return euler_residual
+    # f = u'(c_t) + β * u'(c_{t+1}) * Σ_s [∂m'/∂s' * ∂s'/∂c] = 0
+    return marginal_reward_t + discount_factor * marginal_reward_t1 * return_factor
+
+
+def estimate_euler_residual(
+    bellman_period: BellmanPeriod,
+    df: dict[str, Callable] | Callable,
+    states_t: dict[str, Any],
+    shocks: dict[str, Any],
+    parameters: dict[str, Any] | None = None,
+    agent: str | None = None,
+    controls_t: dict[str, Any] | None = None,
+) -> dict[str, torch.Tensor]:
+    r"""Compute the Euler equation residual for given states and shocks.
+
+    The Euler equation is the first-order condition from the Bellman equation,
+    relating marginal rewards across periods.  For each control variable
+    :math:`c_j`, this function computes the residual:
+
+    .. math::
+
+        f_j = u'(c_{j,t}) + \beta \cdot u'(c_{j,t+1}) \cdot \sum_s \left[
+            \frac{\partial s_{t+1}}{\partial c_{j,t}}
+            \cdot \frac{\partial m'_j}{\partial s_{t+1}}
+        \right]
+
+    At optimality :math:`f_j = 0` for every control :math:`j`.
+
+    The discount factor :math:`\beta` is obtained from the model via
+    ``bellman_period.discount_variable``.
+
+    Following Maliar et al. (2021, JME) Definition 2.7, this function uses two
+    independent shock realizations (AiO expectation operator).
+
+    Parameters
+    ----------
+    bellman_period : BellmanPeriod
+        The Bellman period with transitions, rewards, etc.  The discount factor
+        is extracted from the post-transition variables via
+        ``bellman_period.discount_variable``.
+    df : dict[str, Callable] | Callable
+        Decision function or dict of decision rules.
+    states_t : dict[str, Any]
+        Current state variables (arrival states).
+    shocks : dict[str, Any]
+        Shock realizations for both periods (``{sym}_0`` and ``{sym}_1``).
+    parameters : dict[str, Any] | None, optional
+        Model parameters for calibration.
+    agent : str | None, optional
+        Agent identifier for rewards.
+    controls_t : dict[str, Any] | None, optional
+        Pre-computed period-t controls. When provided, the function skips its
+        internal ``compute_controls`` call for period t.  This is used by
+        ``EulerEquationLoss`` to share the same control tensors between the
+        residual computation and the constraint slack computation.
+
+    Returns
+    -------
+    dict[str, torch.Tensor]
+        Mapping from each control symbol to its Euler residual tensor.
+    """
+    shocks_t, shocks_t_plus_1 = _extract_period_shocks(bellman_period, shocks)
+
+    reward_sym = bellman_period.get_reward_sym(agent)
+
+    # Period-t controls and transition
+    if controls_t is None:
+        controls_t = bellman_period.compute_controls(
+            df, states_t, shocks=shocks_t, parameters=parameters
+        )
+    states_t_plus_1 = bellman_period.transition_function(
+        states_t, controls_t, shocks=shocks_t, parameters=parameters
+    )
+
+    # Period-(t+1) controls (second independent shock draw — AiO)
+    controls_t_plus_1 = bellman_period.compute_controls(
+        df, states_t_plus_1, shocks=shocks_t_plus_1, parameters=parameters
+    )
+
+    control_syms = list(controls_t)
+    if len(control_syms) == 0:
+        raise ValueError("No control variables found in decision function")
+
+    # Resolve discount factor from model
+    post = bellman_period.post_function(
+        states_t, controls_t, shocks=shocks_t, parameters=parameters
+    )
+    discount_factor = bellman_period.resolve_discount_factor(post)
+
+    # Compute Euler residual for each control
+    residuals = {}
+    for control_sym in control_syms:
+        residuals[control_sym] = _euler_residual_single_control(
+            bellman_period,
+            discount_factor,
+            control_sym,
+            reward_sym,
+            states_t,
+            controls_t,
+            states_t_plus_1,
+            controls_t_plus_1,
+            shocks_t,
+            shocks_t_plus_1,
+            parameters,
+            agent,
+        )
+
+    return residuals
+
+
+def estimate_bellman_foc_residual(
+    bellman_period: BellmanPeriod,
+    value_function: Callable,
+    df: dict[str, Callable] | Callable,
+    states_t: dict[str, Any],
+    shocks: dict[str, Any],
+    parameters: dict[str, Any] | None = None,
+    agent: str | None = None,
+) -> dict[str, torch.Tensor]:
+    r"""Compute the first-order condition (FOC) residual from the Bellman equation.
+
+    The Bellman equation is:
+
+    .. math::
+
+        V(s) = \max_c \{ u(s,c,\varepsilon) + \beta E_{\varepsilon'}[V(s')] \}
+
+    The FOC w.r.t. each control :math:`c_j` is:
+
+    .. math::
+
+        \frac{\partial u}{\partial c_j}
+        + \beta \sum_s \frac{\partial V(s')}{\partial s'_s}
+        \cdot \frac{\partial s'_s}{\partial c_j} = 0
+
+    Adding a weighted FOC term to the Bellman loss improves convergence
+    (Maliar et al. 2021, equation 14).
+
+    Unlike :func:`estimate_euler_residual`, which replaces :math:`V'(s')` with
+    the envelope condition :math:`u'(c') \cdot \partial m'/\partial s'`, this
+    function differentiates the value network directly.
+
+    Parameters
+    ----------
+    bellman_period : BellmanPeriod
+        The Bellman period.
+    value_function : Callable
+        Value function ``V(states, shocks, parameters) -> tensor``.
+    df : dict[str, Callable] | Callable
+        Decision function or dict of decision rules.
+    states_t : dict[str, Any]
+        Current state variables.
+    shocks : dict[str, Any]
+        Shock realizations with ``{sym}_0`` and ``{sym}_1`` keys.
+    parameters : dict[str, Any] | None, optional
+        Model parameters.
+    agent : str | None, optional
+        Agent identifier.
+
+    Returns
+    -------
+    dict[str, torch.Tensor]
+        Mapping from each control symbol to its FOC residual tensor.
+    """
+    shocks_t, shocks_t_plus_1 = _extract_period_shocks(bellman_period, shocks)
+    reward_sym = bellman_period.get_reward_sym(agent)
+
+    controls_t = bellman_period.compute_controls(
+        df, states_t, shocks=shocks_t, parameters=parameters
+    )
+    control_syms = list(controls_t)
+
+    post = bellman_period.post_function(
+        states_t, controls_t, shocks=shocks_t, parameters=parameters
+    )
+    discount_factor = bellman_period.resolve_discount_factor(post)
+
+    params_ext = parameters if parameters is not None else {}
+
+    residuals = {}
+    for control_sym in control_syms:
+        c_t, controls_t_grad = _ensure_grad(controls_t, control_sym)
+
+        # u'(c_t) — marginal reward at period t
+        reward_grads = bellman_period.grad_reward_function(
+            states_t,
+            controls_t_grad,
+            wrt={control_sym: c_t},
+            shocks=shocks_t,
+            parameters=parameters,
+            agent=agent,
+            create_graph=True,
+        )
+        mr_t = reward_grads[reward_sym][control_sym]
+        if mr_t is None:
+            raise ValueError(
+                f"Could not compute marginal reward: "
+                f"reward '{reward_sym}' does not depend on control '{control_sym}'"
+            )
+
+        # s' = f(s, c, ε₀) — transition preserving autograd graph through c_t
+        next_states = bellman_period.transition_function(
+            states_t, controls_t_grad, shocks=shocks_t, parameters=parameters
+        )
+
+        # Compute pre-decision state for next period so the value function
+        # sees the variables it expects (e.g. m' from a' and shocks).
+        pre_decision_t1 = bellman_period.compute_pre_decision_state(
+            next_states, shocks=shocks_t_plus_1, parameters=parameters
+        )
+
+        # V(s', ε₁) — continuation value with second independent shock draw
+        v_next = value_function(pre_decision_t1, shocks_t_plus_1, params_ext)
+
+        # ∂V/∂c via autograd chain rule: ∂V/∂s' * ∂s'/∂c
+        dv_dc = torch.autograd.grad(
+            v_next.sum(),
+            c_t,
+            create_graph=True,
+            retain_graph=True,
+            allow_unused=True,
+        )[0]
+
+        if dv_dc is None:
+            raise ValueError(
+                f"Autograd returned None for dV/d{control_sym}. "
+                f"The value function has no differentiable path to control "
+                f"'{control_sym}'. Ensure the value network does not detach "
+                "the computation graph (avoid .detach(), .item(), or "
+                "torch.no_grad() inside value_function)."
+            )
+        if torch.any(torch.isnan(dv_dc)):
+            raise ValueError(
+                f"Autograd gradient dV/d{control_sym} is NaN. "
+                "Check that value_function is properly initialized and "
+                "numerically stable."
+            )
+
+        # FOC: u'(c) + β * ∂V(s',ε')/∂c = 0
+        residuals[control_sym] = mr_t + discount_factor * dv_dc
+
+    return residuals

--- a/src/skagent/bellman.py
+++ b/src/skagent/bellman.py
@@ -712,46 +712,6 @@ class BellmanPeriod:
         return post[dv]
 
 
-def fischer_burmeister(
-    a: torch.Tensor, h: torch.Tensor, eps: float = 1e-12
-) -> torch.Tensor:
-    r"""Compute the Fischer-Burmeister function for smooth complementarity.
-
-    The Fischer-Burmeister function replaces the complementarity conditions
-    :math:`a \geq 0,\; h \geq 0,\; ah = 0` with the equivalent smooth equation:
-
-    .. math::
-
-        \text{FB}(a, h) = a + h - \sqrt{a^2 + h^2} = 0
-
-    This is differentiable everywhere, unlike :math:`\min(a, h) = 0`.
-
-    Following Maliar et al. (2021, JME) equation (25).
-
-    Parameters
-    ----------
-    a : torch.Tensor
-        First argument (e.g., slack variable :math:`1 - c/w`).
-    h : torch.Tensor
-        Second argument (e.g., unit-free Lagrange multiplier).
-    eps : float, optional
-        Regularization constant added inside the square root to keep the
-        gradient finite at the origin. At the default ``eps=1e-12``,
-        ``FB(0, 0) = -sqrt(eps) ≈ -1e-6`` rather than exactly zero.
-        This is below typical convergence tolerances but should be
-        accounted for in tests or with very tight tolerances.
-
-    Returns
-    -------
-    torch.Tensor
-        Fischer-Burmeister residual. Approximately zero when the
-        complementarity conditions are satisfied.
-    """
-    if eps <= 0:
-        raise ValueError(f"eps must be > 0, got {eps}")
-    return a + h - torch.sqrt(a**2 + h**2 + eps)
-
-
 def _extract_period_shocks(
     bellman_period: BellmanPeriod,
     shocks: dict[str, Any],
@@ -1424,13 +1384,15 @@ def estimate_bellman_foc_residual(
         )[0]
 
         if dv_dc is None:
-            raise ValueError(
-                f"Autograd returned None for dV/d{control_sym}. "
-                f"The value function has no differentiable path to control "
-                f"'{control_sym}'. Ensure the value network does not detach "
-                "the computation graph (avoid .detach(), .item(), or "
-                "torch.no_grad() inside value_function)."
+            # Continuation value has no differentiable dependence on this
+            # control; with allow_unused=True this is a legitimate outcome
+            # for multi-control models where only some controls affect V(s').
+            # Treat it as a zero gradient and continue.
+            logging.debug(
+                "Autograd returned None for dV/d%s — treating as zero gradient.",
+                control_sym,
             )
+            dv_dc = torch.zeros_like(c_t)
         if torch.any(torch.isnan(dv_dc)):
             raise ValueError(
                 f"Autograd gradient dV/d{control_sym} is NaN. "

--- a/src/skagent/bellman.py
+++ b/src/skagent/bellman.py
@@ -47,19 +47,40 @@ if TYPE_CHECKING:
 
 
 class BellmanPeriod:
-    """A period of a Bellman / DSOP, wrapping a Block with calibration
-    and decision rules. See module docstring for the timing convention.
+    """
+    A class representing a period of a Bellman or Dynamic Stochastic Optimization Problem.
+
+    This class wraps a Block model with calibration parameters and decision rules,
+    providing methods for computing transitions, decisions, rewards, and their gradients.
 
     Parameters
     ----------
     block : Block
+        The underlying block model containing dynamics, shocks, and reward definitions.
+    discount_variable : str
+        A variable name which represents the discount factor for future value streams.
+    calibration : dict[str, Any]
+        Dictionary of calibration parameters for the model.
+    decision_rules : dict[str, Callable] | None, optional
+        Dictionary mapping control variable names to decision rule functions.
+
+    Attributes
+    ----------
+    block : Block
         The underlying block model.
     discount_variable : str
-        Name of the variable holding the discount factor.
+        The name of the discount factor variable.
     calibration : dict[str, Any]
-        Calibration parameters.
-    decision_rules : dict[str, Callable] | None, optional
-        Mapping from control symbol to decision rule callable.
+        The calibration parameters.
+    decision_rules : dict[str, Callable] | None
+        The decision rules for control variables.
+    arrival_states : set[str]
+        The set of arrival state variable names.
+
+    Notes
+    -----
+    Future versions may introduce an abstract base class to support different
+    block types beyond DBlock/RBlock.
     """
 
     block: Block
@@ -192,11 +213,32 @@ class BellmanPeriod:
         parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
-        Compute control values at *states*.
+        Compute control variable values from a decision function or decision rules.
 
-        Accepts a callable (invoked directly as ``df(states, shocks, params)``)
-        or a dict of decision rules keyed by control symbol (passed through
-        to :meth:`decision_function`).
+        This generalises ``decision_function`` to also accept an external callable
+        with signature ``df(states, shocks, parameters) -> controls``.
+
+        Parameters
+        ----------
+        df : dict[str, Callable] | Callable
+            A callable decision function, or a dict of decision rules passed
+            through to ``decision_function``.
+        states : dict[str, Any]
+            Current state variables.
+        shocks : dict[str, Any] | None, optional
+            Current shock realizations (defaults to empty dict).
+        parameters : dict[str, Any] | None, optional
+            Model parameters (defaults to instance calibration).
+
+        Returns
+        -------
+        dict[str, Any]
+            Control variable values.
+
+        Raises
+        ------
+        TypeError
+            If *df* is neither callable nor a dict.
         """
         shocks = shocks if shocks is not None else {}
         params = parameters if parameters is not None else self.calibration
@@ -376,9 +418,28 @@ class BellmanPeriod:
         agent: str | None = None,
         decision_rules: dict[str, Callable] | None = None,
     ) -> dict[str, Any]:
-        """Return the post-transition output for the period (every
-        variable realized by ``block.transition``). The ``agent``
-        parameter is reserved for future per-agent filtering.
+        """
+        Return the full ex post variables for the period.
+
+        Parameters
+        ----------
+        states : dict[str, Any]
+            Current state variables.
+        controls : dict[str, Any]
+            Current control variable values.
+        shocks : dict[str, Any] | None, optional
+            Current shock realizations (defaults to empty dict).
+        parameters : dict[str, Any] | None, optional
+            Model parameters (defaults to instance calibration).
+        agent : str | None, optional
+            Agent identifier (currently unused, reserved for future use).
+        decision_rules : dict[str, Callable] | None, optional
+            Decision rules (defaults to instance decision_rules).
+
+        Returns
+        -------
+        dict[str, Any]
+            All computed variables from the block transition.
         """
         shocks, decision_rules, parameters = self._resolve_inputs(
             shocks, decision_rules, parameters
@@ -435,11 +496,18 @@ class BellmanPeriod:
             shocks, decision_rules, parameters
         )
 
+        # Combine all variables for block evaluation
         vals = parameters | states | shocks | controls
+
+        # Compute rewards using block transition
+        post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
         # Calls block.transition directly (rather than post_function) to keep
         # the exact computation graph needed for autograd differentiation.
-        post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
+
+        # Filter rewards by agent
         rewards = {sym: post[sym] for sym in self.get_reward_syms(agent)}
+
+        # Use utility function to compute gradients
         return compute_gradients_for_tensors(rewards, wrt, create_graph=create_graph)
 
     def grad_transition_function(
@@ -453,10 +521,40 @@ class BellmanPeriod:
         decision_rules: dict[str, Callable] | None = None,
         create_graph: bool = False,
     ) -> dict[str, dict[str, torch.Tensor | None]]:
-        """Gradients ∂s_{t+1}/∂x for each next-period arrival state and
-        each tensor in *wrt*. ``create_graph=True`` enables higher-order
-        derivatives.
         """
+        Compute gradients of transition function with respect to specified variables.
+
+        This computes ∂s_{t+1}/∂x for each arrival state s_{t+1} and each variable x
+        specified in wrt. This is needed for Euler equations where the gradient of
+        future states with respect to current controls appears (e.g., ∂a_{t+1}/∂c_t = -1
+        for the budget constraint a_{t+1} = m_t - c_t).
+
+        Parameters
+        ----------
+        states : dict[str, Any]
+            State variables.
+        controls : dict[str, Any]
+            Control variables.
+        wrt : dict[str, torch.Tensor]
+            Dictionary of variables to compute gradients with respect to.
+            Keys are variable names, values are tensors with requires_grad=True.
+        shocks : dict[str, Any] | None, optional
+            Shock variables (defaults to empty dict).
+        parameters : dict[str, Any] | None, optional
+            Model parameters (defaults to instance calibration).
+        decision_rules : dict[str, Callable] | None, optional
+            Decision rules of control variables that will _not_ be given to the function.
+        create_graph : bool, optional
+            If True, the graph of the derivative is constructed, allowing higher-order
+            derivatives and end-to-end training through the gradient computation.
+
+        Returns
+        -------
+        dict[str, dict[str, torch.Tensor | None]]
+            Nested dictionary of gradients for each arrival state and variable:
+            {state_sym: {var_name: gradient}}.
+        """
+        # Use the existing transition_function method to compute next states
         next_states = self.transition_function(
             states,
             controls,
@@ -464,6 +562,8 @@ class BellmanPeriod:
             parameters=parameters,
             decision_rules=decision_rules,
         )
+
+        # Use utility function to compute gradients
         return compute_gradients_for_tensors(
             next_states, wrt, create_graph=create_graph
         )
@@ -478,14 +578,53 @@ class BellmanPeriod:
         control_sym: str | None = None,
         create_graph: bool = False,
     ) -> dict[str, dict[str, torch.Tensor | None]]:
-        """Gradients ∂m/∂s of pre-decision state variables m with respect
-        to arrival states s in *wrt*. Used for the envelope condition
-
-            V'(s) = u'(c) · ∂m/∂s.
-
-        If *control_sym* is None, uses the first control with an iset.
         """
+        Compute gradients of pre-decision state variables with respect to arrival states.
+
+        This computes ∂m/∂s for each pre-decision state variable m and each arrival
+        state s specified in wrt. This is needed for the envelope condition in dynamic
+        programming, where the marginal value of an arrival state depends on how
+        that state transforms through the dynamics before reaching the control.
+
+        The "pre-decision state" (or "pre-state") is the state that exists immediately
+        before the control decision is made. For example, cash-on-hand m = Ra + y is
+        the pre-state before consumption c is chosen.
+
+        By the envelope theorem:
+            V'(s) = u'(c) * ∂m/∂s
+
+        where m is the pre-decision state variable that the control depends on.
+
+        For example, in a consumption-saving model with m = a*R + y:
+            ∂m/∂a = R (the return on assets)
+
+        Parameters
+        ----------
+        states : dict[str, Any]
+            Arrival state variables (with requires_grad=True for gradient computation).
+        wrt : dict[str, torch.Tensor]
+            Dictionary of arrival states to compute gradients with respect to.
+            Keys are variable names, values are tensors with requires_grad=True.
+        shocks : dict[str, Any] | None, optional
+            Shock variables (defaults to empty dict).
+        parameters : dict[str, Any] | None, optional
+            Model parameters (defaults to instance calibration).
+        control_sym : str | None, optional
+            Name of the control variable whose info-set we want gradients for.
+            If None, uses the first control found in the block.
+        create_graph : bool, optional
+            If True, the graph of the derivative is constructed, allowing higher-order
+            derivatives and end-to-end training through the gradient computation.
+
+        Returns
+        -------
+        dict[str, dict[str, torch.Tensor | None]]
+            Nested dictionary of gradients for each pre-state variable and arrival state:
+            {pre_state_var: {state_sym: gradient}}.
+        """
+        # Get the control's pre-state variables (stored as iset in the Control)
         if control_sym is None:
+            # Find the first control in dynamics
             for sym, rule in self.block.dynamics.items():
                 if hasattr(rule, "iset"):
                     control_sym = sym
@@ -505,6 +644,7 @@ class BellmanPeriod:
             control_sym, states, shocks=shocks, parameters=parameters
         )
 
+        # Use utility function to compute gradients
         return compute_gradients_for_tensors(
             pre_state_values, wrt, create_graph=create_graph
         )

--- a/src/skagent/bellman.py
+++ b/src/skagent/bellman.py
@@ -1,16 +1,39 @@
 """
-Functions for creating and reasoning about Dynamic Stochastic Optimization Problems (DSOPs).
+Dynamic Stochastic Optimization Problems (DSOPs) built on Block models.
 
-The Block data structure is rather general, and can be used to represent static problems.
+Bellman timing within a period:
 
-Converting Block models into DSOPs involves identifying transition and reward functions,
-and framing them in terms of arrival states, shocks, and decisions.
+    [arrival] + [shock] -> [pre] -> [control] -> [post] -> [arrival']
 
+- [arrival]  ``s``  state on arrival, before any shock
+- [shock]    ``e``  exogenous random variable
+- [pre]      ``m``  pre-decision state (the control's iset)
+- [control]  ``c``  chosen by the decision rule on m
+- [post]            post-transition output: the bag of variables
+                    realized in the period (m, c, u, b, s'),
+                    returned by :meth:`BellmanPeriod.post_function`
+- [arrival'] ``s'`` next-period arrival state
+
+Reward ``u`` and discount ``b`` are realized between [control] and
+[arrival'].
+
+State-variable naming (long / short / informal):
+
+- pre-decision: ``pre_decision_state`` / ``pre_state`` / ``iset``
+
+The Bellman-timing distinction between the post-decision *state* (a
+single timing point) and the post-transition *bag* is conflated in
+``post_function`` for now, and will be split in a future PR.
+
+A ``_rule`` is a user-supplied callable on pre-decision variables; a
+``_function`` is a callable on arrival states. Module-level ``df``
+and ``vf`` are the decision and value callables; each accepts a
+single ``Callable`` or a ``dict[str, Callable]`` (``df`` keyed by
+control symbol; ``vf`` by agent name).
 """
 
 from __future__ import annotations
 
-import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -24,40 +47,19 @@ if TYPE_CHECKING:
 
 
 class BellmanPeriod:
-    """
-    A class representing a period of a Bellman or Dynamic Stochastic Optimization Problem.
-
-    This class wraps a Block model with calibration parameters and decision rules,
-    providing methods for computing transitions, decisions, rewards, and their gradients.
+    """A period of a Bellman / DSOP, wrapping a Block with calibration
+    and decision rules. See module docstring for the timing convention.
 
     Parameters
     ----------
     block : Block
-        The underlying block model containing dynamics, shocks, and reward definitions.
-    discount_variable : str
-        A variable name which represents the discount factor for future value streams.
-    calibration : dict[str, Any]
-        Dictionary of calibration parameters for the model.
-    decision_rules : dict[str, Callable] | None, optional
-        Dictionary mapping control variable names to decision rule functions.
-
-    Attributes
-    ----------
-    block : Block
         The underlying block model.
     discount_variable : str
-        The name of the discount factor variable.
+        Name of the variable holding the discount factor.
     calibration : dict[str, Any]
-        The calibration parameters.
-    decision_rules : dict[str, Callable] | None
-        The decision rules for control variables.
-    arrival_states : set[str]
-        The set of arrival state variable names.
-
-    Notes
-    -----
-    Future versions may introduce an abstract base class to support different
-    block types beyond DBlock/RBlock.
+        Calibration parameters.
+    decision_rules : dict[str, Callable] | None, optional
+        Mapping from control symbol to decision rule callable.
     """
 
     block: Block
@@ -79,23 +81,25 @@ class BellmanPeriod:
         self.decision_rules = decision_rules
         self.arrival_states = self.block.get_arrival_states(calibration)
 
-    def _resolve_decision_rules(
-        self, decision_rules: dict[str, Callable] | None
-    ) -> dict[str, Callable]:
-        """Resolve decision rules with fallback to instance attribute then empty dict."""
-        if decision_rules is not None:
-            return decision_rules
-        if self.decision_rules is not None:
-            return self.decision_rules
-        return {}
-
-    def _resolve_parameters(self, parameters: dict[str, Any] | None) -> dict[str, Any]:
-        """Resolve parameters with fallback to instance calibration."""
-        return parameters if parameters is not None else self.calibration
-
-    def _resolve_shocks(self, shocks: dict[str, Any] | None) -> dict[str, Any]:
-        """Resolve shocks with fallback to empty dict."""
-        return shocks if shocks is not None else {}
+    def _resolve_inputs(
+        self,
+        shocks: dict[str, Any] | None,
+        decision_rules: dict[str, Callable] | None,
+        parameters: dict[str, Any] | None,
+    ) -> tuple[dict[str, Any], dict[str, Callable], dict[str, Any]]:
+        """Resolve ``(shocks, decision_rules, parameters)``, replacing ``None``
+        with defaults: ``{}`` for shocks; instance ``decision_rules`` then
+        ``{}`` for decision_rules; instance calibration for parameters.
+        """
+        if decision_rules is None:
+            decision_rules = self.decision_rules
+        if decision_rules is None:
+            decision_rules = {}
+        return (
+            shocks if shocks is not None else {},
+            decision_rules,
+            parameters if parameters is not None else self.calibration,
+        )
 
     def get_arrival_states(self, calibration: dict[str, Any] | None = None) -> set[str]:
         """Get arrival state variable names for given calibration."""
@@ -150,60 +154,34 @@ class BellmanPeriod:
         """
         return self.get_reward_syms(agent)[0]
 
-    def compute_pre_decision_state(
+    def compute_pre_state(
         self,
+        control_sym: str,
         states: dict[str, Any],
         *,
         shocks: dict[str, Any] | None = None,
         parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Compute the pre-decision state from arrival states and shocks.
+        """Return the pre-decision state values for *control_sym* as
+        ``{var: value}``. The variables are those in the control's
+        information set (``iset``).
 
-        If the control's information set variables (e.g. cash-on-hand ``m``)
-        are not already present in *states*, runs block dynamics from arrival
-        states up to the control to produce them. If they are already present
-        (the control operates directly on arrival states), returns the merged
-        inputs unchanged.
-
-        Parameters
-        ----------
-        states : dict[str, Any]
-            Arrival state variables (e.g., ``{"a": tensor}``).
-        shocks : dict[str, Any] | None, optional
-            Current shock realizations (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-
-        Returns
-        -------
-        dict[str, Any]
-            Merged dict of parameters, arrival states, shocks, and any
-            computed pre-decision variables.
+        If the pre-decision state variables are already in *states* or
+        *shocks*, they are taken from there directly. Otherwise block
+        dynamics are run from arrival states up to the control to
+        produce them.
         """
-        shocks = self._resolve_shocks(shocks)
-        params = self._resolve_parameters(parameters)
-        collision = set(params) & set(states)
-        if collision:
-            raise ValueError(
-                f"compute_pre_decision_state: parameter keys conflict with state keys: "
-                f"{sorted(collision)}. Rename either the parameters or the state "
-                "variables to avoid shadowing."
-            )
+        iset = self.block.dynamics[control_sym].iset
+        shocks = shocks if shocks is not None else {}
+        params = parameters if parameters is not None else self.calibration
         vals = params | states | shocks
 
-        control_sym = next(iter(self.get_controls()))
-        iset = self.block.dynamics[control_sym].iset
-
-        # If the control's iset variables are already available, no
-        # pre-decision computation needed (control operates directly
-        # on arrival states).
         if all(isym in vals for isym in iset):
-            return vals
+            return {isym: vals[isym] for isym in iset}
 
-        # Compute pre-decision dynamics (e.g. m = R*a/ψ + 1 for U-2)
         drs = {cs: (lambda: 1) for cs in self.get_controls()}
-        post = self.block.transition(vals, drs, until=control_sym)
-        return post
+        out = self.block.transition(vals, drs, until=control_sym)
+        return {isym: out[isym] for isym in iset}
 
     def compute_controls(
         self,
@@ -214,36 +192,16 @@ class BellmanPeriod:
         parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
-        Compute control variable values from a decision function or decision rules.
+        Compute control values at *states*.
 
-        This generalises ``decision_function`` to also accept an external callable
-        with signature ``df(states, shocks, parameters) -> controls``.
-
-        Parameters
-        ----------
-        df : dict[str, Callable] | Callable
-            A callable decision function, or a dict of decision rules passed
-            through to ``decision_function``.
-        states : dict[str, Any]
-            Current state variables.
-        shocks : dict[str, Any] | None, optional
-            Current shock realizations (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-
-        Returns
-        -------
-        dict[str, Any]
-            Control variable values.
-
-        Raises
-        ------
-        TypeError
-            If *df* is neither callable nor a dict.
+        Accepts a callable (invoked directly as ``df(states, shocks, params)``)
+        or a dict of decision rules keyed by control symbol (passed through
+        to :meth:`decision_function`).
         """
-        shocks = self._resolve_shocks(shocks)
+        shocks = shocks if shocks is not None else {}
+        params = parameters if parameters is not None else self.calibration
+
         if callable(df):
-            params = self._resolve_parameters(parameters)
             return df(states, shocks, params)
         if not isinstance(df, dict):
             raise TypeError(
@@ -251,8 +209,47 @@ class BellmanPeriod:
                 f"got {type(df).__name__!r}"
             )
         return self.decision_function(
-            states, shocks=shocks, parameters=parameters, decision_rules=df
+            states, shocks=shocks, parameters=params, decision_rules=df
         )
+
+    def compute_value(
+        self,
+        vf: dict[str, Callable] | Callable,
+        states: dict[str, Any],
+        *,
+        shocks: dict[str, Any] | None = None,
+        parameters: dict[str, Any] | None = None,
+        agent: str | None = None,
+    ) -> Any:
+        """
+        Compute value-function output at *states*, parallel to
+        :meth:`compute_controls`.
+
+        Accepts a single callable, or a dict ``{agent: callable}`` from
+        which *agent* selects an entry. The selected callable receives
+        arrival states; any pre-decision (iset) computation it needs is
+        the callable's responsibility.
+        """
+        shocks = shocks if shocks is not None else {}
+        params = parameters if parameters is not None else self.calibration
+
+        if callable(vf):
+            return vf(states, shocks, params)
+        if not isinstance(vf, dict):
+            raise TypeError(
+                f"vf must be a callable value function or a dict mapping "
+                f"agent name to a callable, got {type(vf).__name__!r}"
+            )
+        if agent is None:
+            raise ValueError(
+                "vf is a dict (per-agent value functions); the 'agent' "
+                f"argument must be specified. Available agents: {sorted(vf)}."
+            )
+        if agent not in vf:
+            raise KeyError(
+                f"vf has no entry for agent '{agent}'. Available agents: {sorted(vf)}."
+            )
+        return vf[agent](states, shocks, params)
 
     def transition_function(
         self,
@@ -284,9 +281,9 @@ class BellmanPeriod:
         dict[str, Any]
             Next-period arrival state values.
         """
-        shocks = self._resolve_shocks(shocks)
-        decision_rules = self._resolve_decision_rules(decision_rules)
-        parameters = self._resolve_parameters(parameters)
+        shocks, decision_rules, parameters = self._resolve_inputs(
+            shocks, decision_rules, parameters
+        )
 
         vals = parameters | states | shocks | controls
         post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
@@ -320,9 +317,9 @@ class BellmanPeriod:
         dict[str, Any]
             Control variable values computed from decision rules.
         """
-        shocks = self._resolve_shocks(shocks)
-        decision_rules = self._resolve_decision_rules(decision_rules)
-        parameters = self._resolve_parameters(parameters)
+        shocks, decision_rules, parameters = self._resolve_inputs(
+            shocks, decision_rules, parameters
+        )
 
         vals = parameters | states | shocks
         post = self.block.transition(vals, decision_rules)
@@ -361,9 +358,9 @@ class BellmanPeriod:
         dict[str, Any]
             Reward values for the period.
         """
-        shocks = self._resolve_shocks(shocks)
-        decision_rules = self._resolve_decision_rules(decision_rules)
-        parameters = self._resolve_parameters(parameters)
+        shocks, decision_rules, parameters = self._resolve_inputs(
+            shocks, decision_rules, parameters
+        )
 
         vals = parameters | states | shocks | controls
         post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
@@ -379,32 +376,13 @@ class BellmanPeriod:
         agent: str | None = None,
         decision_rules: dict[str, Callable] | None = None,
     ) -> dict[str, Any]:
+        """Return the post-transition output for the period (every
+        variable realized by ``block.transition``). The ``agent``
+        parameter is reserved for future per-agent filtering.
         """
-        Return the full ex post variables for the period.
-
-        Parameters
-        ----------
-        states : dict[str, Any]
-            Current state variables.
-        controls : dict[str, Any]
-            Current control variable values.
-        shocks : dict[str, Any] | None, optional
-            Current shock realizations (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-        agent : str | None, optional
-            Agent identifier (currently unused, reserved for future use).
-        decision_rules : dict[str, Callable] | None, optional
-            Decision rules (defaults to instance decision_rules).
-
-        Returns
-        -------
-        dict[str, Any]
-            All computed variables from the block transition.
-        """
-        shocks = self._resolve_shocks(shocks)
-        decision_rules = self._resolve_decision_rules(decision_rules)
-        parameters = self._resolve_parameters(parameters)
+        shocks, decision_rules, parameters = self._resolve_inputs(
+            shocks, decision_rules, parameters
+        )
 
         vals = parameters | states | shocks | controls
         post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
@@ -453,22 +431,15 @@ class BellmanPeriod:
             {reward_sym: {var_name: gradient}}. Gradient is None if the reward
             does not depend on the variable.
         """
-        shocks = self._resolve_shocks(shocks)
-        decision_rules = self._resolve_decision_rules(decision_rules)
-        parameters = self._resolve_parameters(parameters)
+        shocks, decision_rules, parameters = self._resolve_inputs(
+            shocks, decision_rules, parameters
+        )
 
-        # Combine all variables for block evaluation
         vals = parameters | states | shocks | controls
-
-        # Compute rewards using block transition
-        post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
         # Calls block.transition directly (rather than post_function) to keep
         # the exact computation graph needed for autograd differentiation.
-
-        # Filter rewards by agent
+        post = self.block.transition(vals, decision_rules, fix=list(controls.keys()))
         rewards = {sym: post[sym] for sym in self.get_reward_syms(agent)}
-
-        # Compute gradients of reward w.r.t. requested variables
         return compute_gradients_for_tensors(rewards, wrt, create_graph=create_graph)
 
     def grad_transition_function(
@@ -482,40 +453,10 @@ class BellmanPeriod:
         decision_rules: dict[str, Callable] | None = None,
         create_graph: bool = False,
     ) -> dict[str, dict[str, torch.Tensor | None]]:
+        """Gradients ∂s_{t+1}/∂x for each next-period arrival state and
+        each tensor in *wrt*. ``create_graph=True`` enables higher-order
+        derivatives.
         """
-        Compute gradients of transition function with respect to specified variables.
-
-        This computes ∂s_{t+1}/∂x for each arrival state s_{t+1} and each variable x
-        specified in wrt. This is needed for Euler equations where the gradient of
-        future states with respect to current controls appears (e.g., ∂a_{t+1}/∂c_t = -1
-        for the budget constraint a_{t+1} = m_t - c_t).
-
-        Parameters
-        ----------
-        states : dict[str, Any]
-            State variables.
-        controls : dict[str, Any]
-            Control variables.
-        wrt : dict[str, torch.Tensor]
-            Dictionary of variables to compute gradients with respect to.
-            Keys are variable names, values are tensors with requires_grad=True.
-        shocks : dict[str, Any] | None, optional
-            Shock variables (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-        decision_rules : dict[str, Callable] | None, optional
-            Decision rules of control variables that will _not_ be given to the function.
-        create_graph : bool, optional
-            If True, the graph of the derivative is constructed, allowing higher-order
-            derivatives and end-to-end training through the gradient computation.
-
-        Returns
-        -------
-        dict[str, dict[str, torch.Tensor | None]]
-            Nested dictionary of gradients for each arrival state and variable:
-            {state_sym: {var_name: gradient}}.
-        """
-        # Use the existing transition_function method to compute next states
         next_states = self.transition_function(
             states,
             controls,
@@ -523,8 +464,6 @@ class BellmanPeriod:
             parameters=parameters,
             decision_rules=decision_rules,
         )
-
-        # Compute gradients of next-state outputs w.r.t. requested variables
         return compute_gradients_for_tensors(
             next_states, wrt, create_graph=create_graph
         )
@@ -539,64 +478,20 @@ class BellmanPeriod:
         control_sym: str | None = None,
         create_graph: bool = False,
     ) -> dict[str, dict[str, torch.Tensor | None]]:
+        """Gradients ∂m/∂s of pre-decision state variables m with respect
+        to arrival states s in *wrt*. Used for the envelope condition
+
+            V'(s) = u'(c) · ∂m/∂s.
+
+        If *control_sym* is None, uses the first control with an iset.
         """
-        Compute gradients of pre-decision state variables with respect to arrival states.
-
-        This computes ∂m/∂s for each pre-decision state variable m and each arrival
-        state s specified in wrt. This is needed for the envelope condition in dynamic
-        programming, where the marginal value of an arrival state depends on how
-        that state transforms through the dynamics before reaching the control.
-
-        The "pre-decision state" (or "pre-state") is the state that exists immediately
-        before the control decision is made. For example, cash-on-hand m = Ra + y is
-        the pre-state before consumption c is chosen.
-
-        By the envelope theorem:
-            V'(s) = u'(c) * ∂m/∂s
-
-        where m is the pre-decision state variable that the control depends on.
-
-        For example, in a consumption-saving model with m = a*R + y:
-            ∂m/∂a = R (the return on assets)
-
-        Parameters
-        ----------
-        states : dict[str, Any]
-            Arrival state variables (with requires_grad=True for gradient computation).
-        wrt : dict[str, torch.Tensor]
-            Dictionary of arrival states to compute gradients with respect to.
-            Keys are variable names, values are tensors with requires_grad=True.
-        shocks : dict[str, Any] | None, optional
-            Shock variables (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-        control_sym : str | None, optional
-            Name of the control variable whose info-set we want gradients for.
-            If None, uses the first control found in the block.
-        create_graph : bool, optional
-            If True, the graph of the derivative is constructed, allowing higher-order
-            derivatives and end-to-end training through the gradient computation.
-
-        Returns
-        -------
-        dict[str, dict[str, torch.Tensor | None]]
-            Nested dictionary of gradients for each pre-state variable and arrival state:
-            {pre_state_var: {state_sym: gradient}}.
-        """
-        shocks = self._resolve_shocks(shocks)
-        parameters = self._resolve_parameters(parameters)
-
-        # Get the control's pre-state variables (stored as iset in the Control)
         if control_sym is None:
-            # Find the first control in dynamics
             for sym, rule in self.block.dynamics.items():
                 if hasattr(rule, "iset"):
                     control_sym = sym
                     break
-
         if control_sym is None:
             raise ValueError("No control with pre-state found in block dynamics")
-
         control_rule = self.block.dynamics.get(control_sym)
         if control_rule is None or not hasattr(control_rule, "iset"):
             raise ValueError(
@@ -605,101 +500,20 @@ class BellmanPeriod:
                 "constructed with an explicit 'iset' argument specifying which "
                 "variables the control depends on."
             )
-        pre_state_vars = control_rule.iset
 
-        # Compute pre-state values using helper method
-        pre_state_values = self._compute_pre_state_values(
-            pre_state_vars, states, shocks=shocks, parameters=parameters
+        pre_state_values = self.compute_pre_state(
+            control_sym, states, shocks=shocks, parameters=parameters
         )
 
-        # Compute gradients of pre-decision state values w.r.t. requested variables
         return compute_gradients_for_tensors(
             pre_state_values, wrt, create_graph=create_graph
         )
 
-    def _compute_pre_state_values(
-        self,
-        pre_state_vars: list[str],
-        states: dict[str, Any],
-        *,
-        shocks: dict[str, Any] | None = None,
-        parameters: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """
-        Compute pre-decision state variable values.
-
-        This is a helper method used by grad_pre_state_function and estimate_euler_residual
-        to compute pre-state values without duplication.
-
-        Parameters
-        ----------
-        pre_state_vars : list[str]
-            List of pre-state variable names (from Control.iset).
-        states : dict[str, Any]
-            Arrival state variables.
-        shocks : dict[str, Any] | None, optional
-            Shock variables (defaults to empty dict).
-        parameters : dict[str, Any] | None, optional
-            Model parameters (defaults to instance calibration).
-
-        Returns
-        -------
-        dict[str, Any]
-            Dictionary mapping pre-state variable names to their computed values.
-        """
-        shocks = self._resolve_shocks(shocks)
-        parameters = self._resolve_parameters(parameters)
-
-        # Build values dict with arrival states and parameters
-        vals = {**states, **shocks, **parameters}
-
-        # Compute pre-state variables by running dynamics up to the control
-        pre_state_values = {}
-        for var_name in pre_state_vars:
-            if var_name in self.arrival_states:
-                # Pre-state variable IS an arrival state, gradient is identity
-                pre_state_values[var_name] = states[var_name]
-            elif var_name in self.block.dynamics:
-                # Compute the dynamics for this variable
-                rule = self.block.dynamics[var_name]
-                if callable(rule):
-                    sig = inspect.signature(rule)
-                    missing = [p for p in sig.parameters if p not in vals]
-                    if missing:
-                        raise KeyError(
-                            f"Pre-state dynamics rule for '{var_name}' requires "
-                            f"parameter(s) {missing} which are not available in "
-                            f"states, shocks, or parameters. "
-                            f"Available keys: {sorted(vals.keys())}"
-                        )
-                    args = {p: vals[p] for p in sig.parameters}
-                    pre_state_values[var_name] = rule(**args)
-                else:
-                    pre_state_values[var_name] = rule
-            else:
-                raise ValueError(
-                    f"Pre-state variable '{var_name}' not found in arrival_states or dynamics"
-                )
-
-        return pre_state_values
-
     def resolve_discount_factor(self, post: dict[str, Any]) -> Any:
-        """Extract the discount factor from post-transition variables.
-
-        Parameters
-        ----------
-        post : dict[str, Any]
-            Output of :meth:`post_function`.
-
-        Returns
-        -------
-        Any
-            The discount factor value.
-
-        Raises
-        ------
-        KeyError
-            If :attr:`discount_variable` is not present in *post*.
+        """Return ``post[self.discount_variable]``, raising ``KeyError``
+        with a diagnostic message if the discount variable is missing.
+        Expects the post-transition output returned by
+        :meth:`post_function`.
         """
         dv = self.discount_variable
         if dv not in post:
@@ -873,7 +687,7 @@ def estimate_discounted_lifetime_reward(
 
 def estimate_bellman_residual(
     bellman_period: BellmanPeriod,
-    value_function: Callable,
+    vf: dict[str, Callable] | Callable,
     df: dict[str, Callable] | Callable,
     states_t: dict[str, Any],
     shocks: dict[str, Any],
@@ -903,14 +717,18 @@ def estimate_bellman_residual(
     bellman_period : BellmanPeriod
         The Bellman period with transitions, rewards, etc. The discount factor is
         extracted from the post-transition variables via ``bellman_period.discount_variable``.
-    value_function : Callable
-        A value function that takes state variables and returns value estimates.
+    vf : dict[str, Callable] | Callable
+        Value function ``vf(states_t, shocks_t, parameters) -> tensor``
+        on arrival states, or a dict mapping ``agent`` name to such a
+        callable for multi-agent models (in which case ``agent`` must be
+        specified). Any pre-decision (iset) computation the underlying
+        approximator needs is the callable's responsibility.
     df : dict[str, Callable] | Callable
-        Decision function that returns controls given states and shocks.
-        Can be a callable with signature df(states_t, shocks_t, parameters) -> controls_t
-        or a dict of decision rules.
+        Decision callable ``df(states_t, shocks_t, parameters) -> controls_t``
+        on arrival states, or a dict of decision rules keyed by control
+        symbol (callables on the iset).
     states_t : dict[str, Any]
-        Current state variables.
+        Current arrival state variables.
     shocks : dict[str, Any]
         Shock realizations for both periods:
         - {shock_sym}_0: period t shocks (for immediate reward and transitions)
@@ -931,46 +749,49 @@ def estimate_bellman_residual(
         If no reward variables are found in the block.
     KeyError
         If required shock variables are missing from the shocks dict.
+
+    Notes
+    -----
+    Single-reward, multi-control: this function returns a single residual
+    tensor, evaluated against the first reward variable matching ``agent``.
+    For multi-control models it complements
+    :func:`estimate_euler_residual` (which returns one residual per
+    control) and :func:`estimate_bellman_foc_residual` (which returns one
+    FOC residual per control by differentiating the value callable).
     """
     shocks_t, shocks_t_plus_1 = _extract_period_shocks(bellman_period, shocks)
 
     reward_sym = bellman_period.get_reward_sym(agent)
 
-    # value_function is an external callable that may not handle None
-    params_ext = parameters if parameters is not None else {}
-
-    # Compute pre-decision state from arrival states + shocks so that
-    # the value function sees the variables it expects (e.g. cash-on-hand
-    # m computed from arrival assets a and shocks).
-    pre_decision_t = bellman_period.compute_pre_decision_state(
-        states_t, shocks=shocks_t, parameters=parameters
+    # V(s_t) — value at the period-t arrival state
+    current_values = bellman_period.compute_value(
+        vf, states_t, shocks=shocks_t, parameters=parameters, agent=agent
     )
 
-    # Get current value estimates (using pre-decision state)
-    current_values = value_function(pre_decision_t, shocks_t, params_ext)
-
-    # Get controls from decision function (using period t shocks)
+    # Controls from decision callable (also takes arrival states)
     controls_t = bellman_period.compute_controls(
         df, states_t, shocks=shocks_t, parameters=parameters
     )
 
-    # Compute immediate reward (using period t shocks)
+    # Immediate reward at period t
     immediate_reward = bellman_period.reward_function(
         states_t, controls_t, shocks=shocks_t, parameters=parameters
     )[reward_sym]
 
-    # Compute next states (using period t shocks)
+    # Next-period arrival state from the transition
     next_states = bellman_period.transition_function(
         states_t, controls_t, shocks=shocks_t, parameters=parameters
     )
 
-    # Compute pre-decision state for next period (arrival states + next shocks)
-    pre_decision_t1 = bellman_period.compute_pre_decision_state(
-        next_states, shocks=shocks_t_plus_1, parameters=parameters
+    # V(s_{t+1}) — continuation value at the next-period arrival state
+    # using the second independent shock draw
+    continuation_values = bellman_period.compute_value(
+        vf,
+        next_states,
+        shocks=shocks_t_plus_1,
+        parameters=parameters,
+        agent=agent,
     )
-
-    # Compute continuation value using value network (using pre-decision state of t+1)
-    continuation_values = value_function(pre_decision_t1, shocks_t_plus_1, params_ext)
 
     # TODO: this is all calling the forward simulation multiple times;
     #       can be made more efficient
@@ -1013,6 +834,12 @@ def _chain_rule_return_factor(
     like: torch.Tensor,
 ) -> torch.Tensor:
     r"""Sum the chain-rule product :math:`\sum_s \partial m'/\partial s' \cdot \partial s'/\partial c`.
+
+    Here :math:`s'` indexes the next-period arrival states, :math:`m'` is
+    the next-period pre-decision state (the variable in the control's
+    information set), and :math:`c` is the period-:math:`t` control. The
+    sum is the envelope-condition return factor used in the Euler
+    residual.
 
     Raises ``ValueError`` if no chain-rule path contributes.
     """
@@ -1272,7 +1099,7 @@ def estimate_euler_residual(
 
 def estimate_bellman_foc_residual(
     bellman_period: BellmanPeriod,
-    value_function: Callable,
+    vf: dict[str, Callable] | Callable,
     df: dict[str, Callable] | Callable,
     states_t: dict[str, Any],
     shocks: dict[str, Any],
@@ -1299,19 +1126,22 @@ def estimate_bellman_foc_residual(
     (Maliar et al. 2021, equation 14).
 
     Unlike :func:`estimate_euler_residual`, which replaces :math:`V'(s')` with
-    the envelope condition :math:`u'(c') \cdot \partial m'/\partial s'`, this
-    function differentiates the value network directly.
+    the envelope condition :math:`u'(c') \cdot \partial m'/\partial s'` (where
+    :math:`m'` is the next-period pre-decision state), this function
+    differentiates the value callable directly.
 
     Parameters
     ----------
     bellman_period : BellmanPeriod
         The Bellman period.
-    value_function : Callable
-        Value function ``V(states, shocks, parameters) -> tensor``.
+    vf : dict[str, Callable] | Callable
+        Value function on arrival states; either a single callable or a
+        per-agent dict. See :func:`estimate_bellman_residual` for the
+        full contract.
     df : dict[str, Callable] | Callable
-        Decision function or dict of decision rules.
+        Decision callable on arrival states, or dict of decision rules.
     states_t : dict[str, Any]
-        Current state variables.
+        Current arrival state variables.
     shocks : dict[str, Any]
         Shock realizations with ``{sym}_0`` and ``{sym}_1`` keys.
     parameters : dict[str, Any] | None, optional
@@ -1336,8 +1166,6 @@ def estimate_bellman_foc_residual(
         states_t, controls_t, shocks=shocks_t, parameters=parameters
     )
     discount_factor = bellman_period.resolve_discount_factor(post)
-
-    params_ext = parameters if parameters is not None else {}
 
     residuals = {}
     for control_sym in control_syms:
@@ -1365,14 +1193,15 @@ def estimate_bellman_foc_residual(
             states_t, controls_t_grad, shocks=shocks_t, parameters=parameters
         )
 
-        # Compute pre-decision state for next period so the value function
-        # sees the variables it expects (e.g. m' from a' and shocks).
-        pre_decision_t1 = bellman_period.compute_pre_decision_state(
-            next_states, shocks=shocks_t_plus_1, parameters=parameters
+        # V(s', ε₁) — continuation value with second independent shock draw,
+        # evaluated on next-period arrival states
+        v_next = bellman_period.compute_value(
+            vf,
+            next_states,
+            shocks=shocks_t_plus_1,
+            parameters=parameters,
+            agent=agent,
         )
-
-        # V(s', ε₁) — continuation value with second independent shock draw
-        v_next = value_function(pre_decision_t1, shocks_t_plus_1, params_ext)
 
         # ∂V/∂c via autograd chain rule: ∂V/∂s' * ∂s'/∂c
         dv_dc = torch.autograd.grad(
@@ -1396,8 +1225,7 @@ def estimate_bellman_foc_residual(
         if torch.any(torch.isnan(dv_dc)):
             raise ValueError(
                 f"Autograd gradient dV/d{control_sym} is NaN. "
-                "Check that value_function is properly initialized and "
-                "numerically stable."
+                "Check that vf is properly initialized and numerically stable."
             )
 
         # FOC: u'(c) + β * ∂V(s',ε')/∂c = 0

--- a/src/skagent/loss.py
+++ b/src/skagent/loss.py
@@ -223,11 +223,26 @@ class EstimatedDiscountedLifetimeRewardLoss:
 
 class _EquationLossBase(ABC):
     """
-    Private base class for Bellman and Euler equation losses.
+    Private base class for losses defined as squared residuals of the
+    Bellman period's optimality conditions.
 
-    Stores shared setup (bellman_period, arrival_variables, shock_syms, reward
-    validation) and provides ``_extract_states_and_shocks`` to avoid duplicate
-    grid-extraction logic in subclass ``__call__`` methods.
+    Both subclasses (:class:`BellmanEquationLoss`, :class:`EulerEquationLoss`)
+    take input grids that follow the AiO contract from Maliar et al. (2021,
+    Definition 2.7): arrival states plus two independent shock realizations
+    per period, encoded as ``{sym}_0`` (period t) and ``{sym}_1`` (period
+    t+1). The base class:
+
+    - validates that the given agent has at least one reward variable
+      defined in ``bellman_period``;
+    - centralizes storage of ``bellman_period``, ``parameters``, ``agent``,
+      ``arrival_variables``, and ``shock_syms``; and
+    - provides :meth:`_extract_states_and_shocks` to deduplicate
+      grid-extraction logic in subclass ``__call__`` methods.
+
+    Subclasses differ in what optimality condition they evaluate (Bellman
+    residual vs Euler residual), whether they require a value callable, and
+    whether they support inequality constraints; they share the input
+    contract above.
     """
 
     def __init__(
@@ -323,13 +338,18 @@ class BellmanEquationLoss(_EquationLossBase):
     Parameters
     ----------
     bellman_period : BellmanPeriod
-        The model block containing dynamics, rewards, and shocks
-    value_network : callable
-        A value function that takes state variables and returns value estimates
+        The model block containing dynamics, rewards, and shocks.
+    value_function : dict[str, Callable] | Callable
+        Value function ``vf(states_t, shocks_t, parameters) -> tensor``
+        on arrival states, or a dict mapping agent name to such a
+        callable for multi-agent models. Any pre-decision (iset)
+        computation the underlying approximator needs is the callable's
+        responsibility.
     parameters : dict, optional
-        Model parameters for calibration
+        Model parameters for calibration.
     agent : str, optional
-        Agent identifier for rewards
+        Agent identifier for rewards. Required when ``value_function`` is
+        a dict.
     foc_weight : float, optional
         Weight :math:`v` on the FOC residual term (default: 0.0, pure Bellman).
         Positive values add the FOC loss to improve convergence.
@@ -338,19 +358,20 @@ class BellmanEquationLoss(_EquationLossBase):
     def __init__(
         self,
         bellman_period: BellmanPeriod,
-        value_network: Callable,
+        value_function: dict[str, Callable] | Callable,
         parameters: dict[str, Any] | None = None,
         agent: str | None = None,
         foc_weight: float = 0.0,
     ) -> None:
         super().__init__(bellman_period, parameters=parameters, agent=agent)
-        if not callable(value_network):
+        if not callable(value_function) and not isinstance(value_function, dict):
             raise TypeError(
-                f"value_network must be callable, got {type(value_network).__name__}"
+                "value_function must be a callable or a dict mapping agent "
+                f"name to a callable, got {type(value_function).__name__}"
             )
         if foc_weight < 0:
             raise ValueError(f"foc_weight must be >= 0, got {foc_weight}")
-        self.value_network = value_network
+        self.value_function = value_function
         self.foc_weight = foc_weight
 
     def __call__(self, df: Callable, input_grid: Grid) -> torch.Tensor:
@@ -375,7 +396,7 @@ class BellmanEquationLoss(_EquationLossBase):
 
         bellman_residual = estimate_bellman_residual(
             self.bellman_period,
-            self.value_network,
+            self.value_function,
             df,
             states_t,
             shocks,
@@ -388,7 +409,7 @@ class BellmanEquationLoss(_EquationLossBase):
         if self.foc_weight > 0:
             foc_residuals = estimate_bellman_foc_residual(
                 self.bellman_period,
-                self.value_network,
+                self.value_function,
                 df,
                 states_t,
                 shocks,
@@ -447,6 +468,15 @@ class EulerEquationLoss(_EquationLossBase):
     For controls without an explicit ``upper_bound``, the loss falls back to the
     one-sided :math:`\\text{relu}(-f)^2` formulation.
 
+    **Scope: upper bounds only.**
+    The constrained mode currently models the upper-bound side of the
+    complementarity condition: :math:`f \\geq 0`, :math:`s = ub - c \\geq
+    0`, :math:`f \\cdot s = 0`. Although ``Control`` accepts both
+    ``lower_bound`` and ``upper_bound``, lower-bound constraints are not
+    yet handled here; bilateral support requires also flipping the
+    residual sign for lower-binding cases (``FB(-f, c - lb)``) and is
+    left as a follow-up.
+
     Parameters
     ----------
     bellman_period : BellmanPeriod
@@ -500,10 +530,12 @@ class EulerEquationLoss(_EquationLossBase):
     def _compute_slack(
         self, control_sym: str, controls_t: dict, states_t: dict, shocks_t: dict
     ) -> torch.Tensor | None:
-        """Compute constraint slack for a control with an upper bound.
+        """Compute upper-bound slack ``upper_bound - control_value``.
 
-        Returns ``upper_bound - control_value``, or ``None`` if the control
-        has no upper bound defined.
+        Returns ``None`` if the control has no upper bound defined. This
+        helper currently handles only the upper-bound side of the
+        complementarity condition; see the class-level docstring for the
+        scope rationale and the lower-bound follow-up.
         """
         control_obj = self.bellman_period.block.dynamics.get(control_sym)
         if (
@@ -513,11 +545,8 @@ class EulerEquationLoss(_EquationLossBase):
         ):
             return None
 
-        pre_state = self.bellman_period._compute_pre_state_values(
-            control_obj.iset,
-            states_t,
-            shocks=shocks_t,
-            parameters=self.parameters,
+        pre_state = self.bellman_period.compute_pre_state(
+            control_sym, states_t, shocks=shocks_t, parameters=self.parameters
         )
 
         sig = inspect.signature(control_obj.upper_bound)

--- a/src/skagent/loss.py
+++ b/src/skagent/loss.py
@@ -14,9 +14,9 @@ from skagent.bellman import (
     estimate_bellman_residual,
     estimate_discounted_lifetime_reward,
     estimate_euler_residual,
-    fischer_burmeister,
 )
 from skagent.grid import Grid
+from skagent.utils import fischer_burmeister
 
 if TYPE_CHECKING:
     from skagent.bellman import BellmanPeriod
@@ -395,7 +395,7 @@ class BellmanEquationLoss(_EquationLossBase):
                 self.parameters,
                 self.agent,
             )
-            foc_loss = sum((r**2 for r in foc_residuals.values()), torch.tensor(0.0))
+            foc_loss = sum((r**2 for r in foc_residuals.values()), 0.0)
             loss = loss + self.foc_weight * foc_loss
 
         return loss
@@ -563,7 +563,7 @@ class EulerEquationLoss(_EquationLossBase):
                 controls_t=controls_t,
             )
 
-            total = torch.tensor(0.0)
+            total = 0.0
             for ctrl_sym, residual in euler_residuals.items():
                 slack = self._compute_slack(ctrl_sym, controls_t, states_t, shocks_t)
                 if slack is not None:
@@ -581,6 +581,4 @@ class EulerEquationLoss(_EquationLossBase):
             self.parameters,
             self.agent,
         )
-        return self.weight * sum(
-            (r**2 for r in euler_residuals.values()), torch.tensor(0.0)
-        )
+        return self.weight * sum((r**2 for r in euler_residuals.values()), 0.0)

--- a/src/skagent/loss.py
+++ b/src/skagent/loss.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import inspect
 import logging
-from typing import TYPE_CHECKING, Any
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 import torch
 
 from skagent.bellman import (
     _extract_period_shocks,
+    estimate_bellman_foc_residual,
     estimate_bellman_residual,
     estimate_discounted_lifetime_reward,
     estimate_euler_residual,
+    fischer_burmeister,
 )
 from skagent.grid import Grid
 
@@ -24,8 +28,8 @@ def static_reward(
     bellman_period,
     dr,
     states,
-    shocks={},
-    parameters={},
+    shocks=None,
+    parameters=None,
     agent=None,
 ):
     """
@@ -46,6 +50,10 @@ def static_reward(
     agent : str or None, optional
         Name of reference agent for rewards.
     """
+    if shocks is None:
+        shocks = {}
+    if parameters is None:
+        parameters = {}
     if callable(dr):
         controls = dr(states, shocks, parameters)
     else:
@@ -72,6 +80,24 @@ def static_reward(
     return reward[rsym]
 
 
+def _prepare_loss_inputs(
+    model_obj,
+    input_grid: Grid,
+    state_variables: set[str],
+    other_dr: dict,
+    new_dr: dict,
+) -> tuple[dict, dict, dict]:
+    """Extract states, shocks, and merged decision rules from an input grid.
+
+    *new_dr* takes precedence over *other_dr* for any overlapping keys.
+    """
+    given_vals = input_grid.to_dict()
+    shock_vals = {sym: input_grid[sym] for sym in model_obj.get_shocks()}
+    states = {sym: given_vals[sym] for sym in state_variables}
+    fresh_dr = {**other_dr, **new_dr}
+    return states, shock_vals, fresh_dr
+
+
 class CustomLoss:
     """
     A custom loss function that computes the negative reward for a block,
@@ -80,33 +106,25 @@ class CustomLoss:
     TODO: leaving this as ambiguously about Blocks and BellmanPeriods for now
     """
 
-    def __init__(self, loss_function, block, parameters=None, other_dr=dict()):
+    def __init__(self, loss_function, block, parameters=None, other_dr=None):
         self.block = block
         self.parameters = parameters
-        self.state_variables = self.block.arrival_states
-        self.other_dr = other_dr
+        self.arrival_variables = self.block.arrival_states
+        self.other_dr = other_dr if other_dr is not None else {}
         self.loss_function = loss_function
 
     def __call__(self, new_dr, input_grid: Grid):
         """
         new_dr : dict of callable
         """
-        ## includes the values of state_0 variables, and shocks.
-        given_vals = input_grid.to_dict()
-
-        ## most variable part -- many uses of double shocks
-        shock_vars = self.block.get_shocks()
-        shock_vals = {sym: input_grid[sym] for sym in shock_vars}
-
-        # override any decision rules if necessary
-        fresh_dr = {**self.other_dr, **new_dr}
+        states, shock_vals, fresh_dr = _prepare_loss_inputs(
+            self.block, input_grid, self.arrival_variables, self.other_dr, new_dr
+        )
 
         neg_loss = self.loss_function(
             self.block,
-            fresh_dr,  # useful
-            {
-                sym: given_vals[sym] for sym in self.state_variables
-            },  # replace with arrival states
+            fresh_dr,
+            states,
             parameters=self.parameters,
             shocks=shock_vals,
         )
@@ -119,33 +137,31 @@ class StaticRewardLoss:
     assuming it is executed just once (a non-dynamic model)
     """
 
-    def __init__(self, bellman_period, parameters, other_dr=dict()):
+    def __init__(self, bellman_period, parameters, other_dr=None):
         self.bellman_period = bellman_period
         self.parameters = parameters
-        self.state_variables = self.bellman_period.arrival_states
-        self.other_dr = other_dr
+        self.arrival_variables = self.bellman_period.arrival_states
+        self.other_dr = other_dr if other_dr is not None else {}
 
     def __call__(self, new_dr, input_grid: Grid):
         """
         new_dr : dict of callable
         """
-        ## includes the values of state_0 variables, and shocks.
-        given_vals = input_grid.to_dict()
-
-        shock_vars = self.bellman_period.get_shocks()
-        shock_vals = {sym: input_grid[sym] for sym in shock_vars}
-
-        # override any decision rules if necessary
-        fresh_dr = {**self.other_dr, **new_dr}
+        states, shock_vals, fresh_dr = _prepare_loss_inputs(
+            self.bellman_period,
+            input_grid,
+            self.arrival_variables,
+            self.other_dr,
+            new_dr,
+        )
 
         r = static_reward(
             self.bellman_period,
             fresh_dr,
-            {sym: given_vals[sym] for sym in self.state_variables},
+            states,
             parameters=self.parameters,
             agent=None,  ## TODO: Pass through the agent?
             shocks=shock_vals,
-            ## Handle multiple decision rules?
         )
         return -r
 
@@ -166,10 +182,10 @@ class EstimatedDiscountedLifetimeRewardLoss:
     def __init__(self, bellman_period, big_t, parameters):
         self.bellman_period = bellman_period
         self.parameters = parameters
-        self.state_variables = self.bellman_period.arrival_states
+        self.arrival_variables = self.bellman_period.arrival_states
         self.big_t = big_t
 
-    def __call__(self, df: callable, input_grid: Grid):
+    def __call__(self, df: Callable, input_grid: Grid):
         # convoluted
         shock_vars = self.bellman_period.get_shocks()
         big_t_shock_syms = sum(
@@ -195,7 +211,7 @@ class EstimatedDiscountedLifetimeRewardLoss:
         edlr = estimate_discounted_lifetime_reward(
             self.bellman_period,
             df,
-            {sym: given_vals[sym] for sym in self.state_variables},
+            {sym: given_vals[sym] for sym in self.arrival_variables},
             self.big_t,
             parameters=self.parameters,
             agent=None,  # TODO: Pass through the agent?
@@ -205,7 +221,7 @@ class EstimatedDiscountedLifetimeRewardLoss:
         return -edlr
 
 
-class _EquationLossBase:
+class _EquationLossBase(ABC):
     """
     Private base class for Bellman and Euler equation losses.
 
@@ -214,29 +230,34 @@ class _EquationLossBase:
     grid-extraction logic in subclass ``__call__`` methods.
     """
 
-    bellman_period: BellmanPeriod
-    parameters: dict[str, Any] | None
-    arrival_variables: set[str]
-    shock_syms: list[str]
-    agent: str | None
-
     def __init__(
         self,
         bellman_period: BellmanPeriod,
         parameters: dict[str, Any] | None = None,
         agent: str | None = None,
     ) -> None:
+        from skagent.bellman import BellmanPeriod as _BellmanPeriod
+
+        if not isinstance(bellman_period, _BellmanPeriod):
+            raise TypeError(
+                f"bellman_period must be a BellmanPeriod, "
+                f"got {type(bellman_period).__name__}"
+            )
         self.bellman_period = bellman_period
         self.parameters = parameters
-        self.arrival_variables = bellman_period.arrival_states
+        # Defensive copy to prevent external mutation of arrival_states
+        self.arrival_variables: set[str] = set(bellman_period.arrival_states)
 
         shock_vars = self.bellman_period.get_shocks()
-        self.shock_syms = list(shock_vars.keys())
+        self.shock_syms: list[str] = list(shock_vars.keys())
 
-        self.agent = agent
+        self.agent: str | None = agent
 
         # Validate that reward variables exist (raises ValueError with agent context)
         bellman_period.get_reward_sym(agent)
+
+    @abstractmethod
+    def __call__(self, df: Callable, input_grid: Grid) -> torch.Tensor: ...
 
     def _extract_states_and_shocks(
         self, input_grid: Grid
@@ -262,22 +283,17 @@ class _EquationLossBase:
             )
         states_t = {sym: given_vals[sym] for sym in self.arrival_variables}
 
-        # Build the combined shock dict and validate keys via _extract_period_shocks
-        shocks = {
-            f"{sym}_{i}": given_vals[f"{sym}_{i}"]
-            for sym in self.shock_syms
-            for i in (0, 1)
-            if f"{sym}_{i}" in given_vals
-        }
-        # Delegate validation to the canonical shock-extraction function
-        _extract_period_shocks(self.bellman_period, shocks)
-
-        # Re-build the full shock dict (including any keys that passed validation)
-        shocks = {
-            f"{sym}_{i}": given_vals[f"{sym}_{i}"]
-            for sym in self.shock_syms
-            for i in (0, 1)
-        }
+        # Build the combined shock dict — let _extract_period_shocks validate
+        # and produce informative error messages for missing keys
+        shock_keys = [f"{sym}_{i}" for sym in self.shock_syms for i in (0, 1)]
+        missing_shocks = [k for k in shock_keys if k not in given_vals]
+        if missing_shocks:
+            raise KeyError(
+                f"Missing shock variable(s) {missing_shocks} in input_grid. "
+                f"Expected two independent realizations per shock: "
+                f"{shock_keys}."
+            )
+        shocks = {k: given_vals[k] for k in shock_keys}
 
         return states_t, shocks
 
@@ -289,6 +305,16 @@ class BellmanEquationLoss(_EquationLossBase):
     The Bellman equation is: V(s) = max_c { u(s,c,ε) + β E_ε'[V(s')] }
     where s' = f(s,c,ε) is the next state given current state s, control c, and shock ε,
     and the expectation E_ε' is taken over future shock realizations ε'.
+
+    When ``foc_weight > 0``, the loss includes a first-order condition (FOC) term
+    derived from the Bellman equation (equation 14 of Maliar et al. 2021):
+
+    .. math::
+
+        L = f_{\\text{Bellman}}^2 + v \\cdot f_{\\text{FOC}}^2
+
+    where :math:`f_{\\text{FOC}}` is the FOC residual
+    :math:`u'(c) + \\beta \\, \\partial V(s')/\\partial c = 0`.
 
     This function expects the input grid to contain two independent shock realizations:
     - {shock_sym}_0: shocks for period t (used for immediate reward and transitions)
@@ -304,13 +330,30 @@ class BellmanEquationLoss(_EquationLossBase):
         Model parameters for calibration
     agent : str, optional
         Agent identifier for rewards
+    foc_weight : float, optional
+        Weight :math:`v` on the FOC residual term (default: 0.0, pure Bellman).
+        Positive values add the FOC loss to improve convergence.
     """
 
-    def __init__(self, bellman_period, value_network, parameters=None, agent=None):
+    def __init__(
+        self,
+        bellman_period: BellmanPeriod,
+        value_network: Callable,
+        parameters: dict[str, Any] | None = None,
+        agent: str | None = None,
+        foc_weight: float = 0.0,
+    ) -> None:
         super().__init__(bellman_period, parameters=parameters, agent=agent)
+        if not callable(value_network):
+            raise TypeError(
+                f"value_network must be callable, got {type(value_network).__name__}"
+            )
+        if foc_weight < 0:
+            raise ValueError(f"foc_weight must be >= 0, got {foc_weight}")
         self.value_network = value_network
+        self.foc_weight = foc_weight
 
-    def __call__(self, df, input_grid: Grid):
+    def __call__(self, df: Callable, input_grid: Grid) -> torch.Tensor:
         """
         Bellman equation loss function.
 
@@ -326,7 +369,7 @@ class BellmanEquationLoss(_EquationLossBase):
         Returns
         -------
         torch.Tensor
-            Bellman equation residual loss (squared)
+            Bellman equation residual loss (squared), optionally with FOC term.
         """
         states_t, shocks = self._extract_states_and_shocks(input_grid)
 
@@ -340,7 +383,22 @@ class BellmanEquationLoss(_EquationLossBase):
             self.agent,
         )
 
-        return bellman_residual**2
+        loss = bellman_residual**2
+
+        if self.foc_weight > 0:
+            foc_residuals = estimate_bellman_foc_residual(
+                self.bellman_period,
+                self.value_network,
+                df,
+                states_t,
+                shocks,
+                self.parameters,
+                self.agent,
+            )
+            foc_loss = sum((r**2 for r in foc_residuals.values()), torch.tensor(0.0))
+            loss = loss + self.foc_weight * foc_loss
+
+        return loss
 
 
 class EulerEquationLoss(_EquationLossBase):
@@ -361,180 +419,67 @@ class EulerEquationLoss(_EquationLossBase):
     where :math:`f` is the residual that equals zero at optimality, :math:`s_{t+1}` is
     the next-period arrival state, and :math:`m'` is the pre-decision state.
 
-    **Derivation:**
+    The discount factor :math:`\\beta` is obtained from the ``BellmanPeriod`` via
+    ``bellman_period.discount_variable``, so it adapts to the model's calibration.
 
-    The first-order condition from the Bellman equation is:
+    **Multi-control support:**
 
-    .. math::
+    For models with :math:`J` control variables, a separate Euler residual is
+    computed per control.  The loss sums over all controls:
+    :math:`L = \\sum_j w \\cdot f_j^2`.
 
-        u'(x_t) = -\\beta E\\left[V'(s_{t+1}) \\cdot \\frac{\\partial s_{t+1}}{\\partial x_t}\\right]
+    **Handling Inequality Constraints (Fischer-Burmeister):**
 
-    By the envelope theorem, :math:`V'(s') = u'(x') \\cdot \\frac{\\partial m'}{\\partial s'}`.
-
-    **Example (consumption-saving):** For :math:`a_{t+1} = m_t - c_t` where
-    :math:`m_t = R \\cdot a_t + y_t` (cash-on-hand):
-
-    - Transition gradient: :math:`\\frac{\\partial a_{t+1}}{\\partial c_t} = -1`
-    - Pre-state gradient: :math:`\\frac{\\partial m'}{\\partial a_{t+1}} = R`
-    - Combined: :math:`R \\cdot (-1) = -R`
-
-    This gives :math:`f = u'(c_t) - \\beta R \\cdot u'(c_{t+1}) = 0` at optimality,
-    which is the standard Euler equation :math:`u'(c_t) = \\beta R E[u'(c_{t+1})]`.
-
-    **Handling Inequality Constraints:**
-
-    When the control has an **upper-bound** constraint (e.g., :math:`x \\leq \\bar{x}`),
-    the Euler equation becomes an inequality at constrained points:
+    When ``constrained=True`` and a control has an ``upper_bound`` defined on its
+    ``Control`` object, the complementarity conditions
 
     .. math::
 
-        u'(x_t) \\geq -\\beta E\\left[V'(s_{t+1}) \\cdot \\frac{\\partial s_{t+1}}{\\partial x_t}\\right]
+        f \\geq 0, \\quad s \\geq 0, \\quad f \\cdot s = 0
 
-    At the upper bound, the residual :math:`f > 0` is optimal. Set ``constrained=True``
-    to use a one-sided loss :math:`L = E[\\max(0, -f)^2]` that only penalizes negative
-    residuals, which is the appropriate formulation for upper-bound constrained controls.
-
-    For example, in a buffer stock consumption model with :math:`c \\leq m`, the agent
-    cannot consume more than cash-on-hand. At the constraint, :math:`u'(c) > \\beta R E[u'(c')]`,
-    so the residual is positive and should not be penalized.
-
-    .. note::
-        The current implementation handles **upper-bound** constraints on the control
-        (residual > 0 at the constraint, penalize via :math:`\\text{relu}(-f)^2`).
-        **Lower-bound** constraints (where the residual would be < 0 at the constraint,
-        requiring :math:`\\text{relu}(f)^2`) are not yet supported.
-
-    **Methodology:**
-
-    This follows the Maliar et al. (2021) methodology (Definition 2.7, equations 9-12)
-    and is designed for use with the all-in-one (AiO) expectation operator.
-
-    The implementation computes the Euler residual using two independent shock
-    realizations (:math:`\\varepsilon_0` for period :math:`t` and :math:`\\varepsilon_1`
-    for period :math:`t+1`), then squares it. The loss is:
+    (where :math:`s` is the constraint slack) are replaced by the smooth
+    Fischer-Burmeister equation (Maliar et al. 2021, equation 25):
 
     .. math::
 
-        L(\\theta) = E[f^2]
+        \\text{FB}(f, s) = f + s - \\sqrt{f^2 + s^2} = 0
 
-    where :math:`f` is the Euler equation residual computed with both shock realizations.
-
-    For constrained problems, the loss uses the one-sided formulation:
-
-    .. math::
-
-        L(\\theta) = E[\\max(0, -f)^2]
-
-    which only penalizes negative residuals.
-
-    **Notation:**
-
-    We use :math:`\\varepsilon` (epsilon) to denote exogenous shocks, following standard
-    convention for stochastic disturbances. This is functionally equivalent to the shock
-    notation in Maliar et al. (2021).
-
-    **Input Grid Structure:**
-
-    This function expects the input grid to contain two independent shock realizations:
-
-    - ``{shock_sym}_0``: shocks for transitions from t to t+1
-    - ``{shock_sym}_1``: shocks for transitions from t+1 to t+2 (independent of period t)
+    For controls without an explicit ``upper_bound``, the loss falls back to the
+    one-sided :math:`\\text{relu}(-f)^2` formulation.
 
     Parameters
     ----------
     bellman_period : BellmanPeriod
-        The model block containing dynamics, rewards, and shocks
-    discount_factor : float
-        The discount factor β (time preference parameter).
-
-        .. note::
-            In a future version, the discount factor may be obtained from the
-            BellmanPeriod object directly rather than passed as a parameter.
-
+        The model block containing dynamics, rewards, and shocks.
     parameters : dict, optional
-        Model parameters for calibration
+        Model parameters for calibration.
     agent : str, optional
-        Agent identifier for rewards
+        Agent identifier for rewards.
     weight : float, optional
-        Exogenous weight for combining multiple optimality conditions (default: 1.0)
-        This corresponds to the vector v in equation (12) of the paper.
+        Exogenous weight for combining multiple optimality conditions (default: 1.0).
+        This corresponds to the vector :math:`v` in equation (12) of the paper.
     constrained : bool, optional
-        If True, use one-sided loss for upper-bound constrained controls (default: False).
-        When True, only negative Euler residuals are penalized. Positive residuals
-        are not penalized because they indicate the control is at its upper bound,
-        which is optimal behavior under the Kuhn-Tucker conditions.
-
-    Notes
-    -----
-    This implementation follows Maliar, Maliar, and Winant (2021, JME) Section 2.2
-    and Section 4.4 for the consumption-saving problem with Kuhn-Tucker conditions.
-
-    **Current Limitations:**
-
-    - Only single-control models are currently supported. Models with multiple
-      control variables will raise a ``NotImplementedError``.
-    - State-dependent discount factors are not yet supported.
-
-    The Euler equation automatically adapts to your model's structure. For example:
-
-    - Consumption-saving: :math:`u(c) = \\log(c)`, with :math:`a_{t+1} = m_t - c_t`
-      where :math:`m_t = R \\cdot a_t + y_t`. Transition gradient
-      :math:`\\partial a_{t+1}/\\partial c_t = -1` and pre-state gradient
-      :math:`\\partial m'/\\partial a' = R` combine to give :math:`-R`.
-      Euler equation becomes: :math:`u'(c_t) = \\beta R u'(c_{t+1})`
-    - With permanent income: :math:`u(c/P)` where :math:`P` evolves with shocks.
-      Multiple transition gradients are summed automatically.
+        If True, use Fischer-Burmeister or one-sided loss for upper-bound
+        constrained controls (default: False).
 
     Examples
     --------
-    >>> # Euler equation adapts to your block's reward structure
-    >>> block = DBlock(
-    ...     shocks={"income": Normal(mu=1.0, sigma=0.1)},
-    ...     dynamics={
-    ...         "consumption": Control(iset=["wealth"]),
-    ...         "wealth": lambda wealth, income, consumption, R:
-    ...             R * (wealth - consumption) + income,
-    ...         "utility": lambda consumption: torch.log(consumption),
-    ...     },
-    ...     reward={"utility": "consumer"}
-    ... )
     >>> bp = BellmanPeriod(block, "beta", calibration={"R": 1.04, "beta": 0.95})
-    >>> loss_fn = EulerEquationLoss(bp, discount_factor=0.95, parameters={"R": 1.04, "beta": 0.95})
-    >>>
-    >>> # Create input grid with two shock realizations
-    >>> input_grid = Grid.from_dict({
-    ...     "wealth": torch.linspace(1.0, 10.0, 50),
-    ...     "income_0": torch.ones(50),      # First shock realization
-    ...     "income_1": torch.ones(50) * 1.1 # Second independent realization
-    ... })
-    >>>
-    >>> # Compute loss for a decision function
-    >>> loss = loss_fn(my_decision_function, input_grid)
-    >>>
-    >>> # For a model with upper-bound constrained control (e.g., buffer stock c <= m):
-    >>> loss_fn_constrained = EulerEquationLoss(
-    ...     bp, discount_factor=0.95, parameters={"R": 1.04}, constrained=True
-    ... )
+    >>> loss_fn = EulerEquationLoss(bp, parameters={"R": 1.04, "beta": 0.95})
     """
 
     def __init__(
         self,
-        bellman_period,
-        discount_factor,
-        parameters=None,
-        agent=None,
-        weight=1.0,
-        constrained=False,
-    ):
-        if callable(discount_factor):
-            raise ValueError(
-                "Currently only numerical, not state-dependent, discount factors are supported."
-            )
-
+        bellman_period: BellmanPeriod,
+        parameters: dict[str, Any] | None = None,
+        agent: str | None = None,
+        weight: float = 1.0,
+        constrained: bool = False,
+    ) -> None:
         super().__init__(bellman_period, parameters=parameters, agent=agent)
 
-        self.discount_factor = discount_factor
-
+        if weight <= 0:
+            raise ValueError(f"weight must be > 0, got {weight}")
         self.weight = weight
         self.constrained = constrained
 
@@ -547,11 +492,41 @@ class EulerEquationLoss(_EquationLossBase):
             if not has_upper_bound:
                 logger.warning(
                     "constrained=True but no Control in the block has an upper_bound. "
-                    "The one-sided loss is intended for models with upper-bound "
-                    "constraints on controls (e.g., c <= m)."
+                    "The one-sided loss will use relu(-f)^2 as a fallback. "
+                    "Define upper_bound on Control objects to enable the "
+                    "Fischer-Burmeister formulation."
                 )
 
-    def __call__(self, df, input_grid: Grid):
+    def _compute_slack(
+        self, control_sym: str, controls_t: dict, states_t: dict, shocks_t: dict
+    ) -> torch.Tensor | None:
+        """Compute constraint slack for a control with an upper bound.
+
+        Returns ``upper_bound - control_value``, or ``None`` if the control
+        has no upper bound defined.
+        """
+        control_obj = self.bellman_period.block.dynamics.get(control_sym)
+        if (
+            control_obj is None
+            or not hasattr(control_obj, "upper_bound")
+            or control_obj.upper_bound is None
+        ):
+            return None
+
+        pre_state = self.bellman_period._compute_pre_state_values(
+            control_obj.iset,
+            states_t,
+            shocks=shocks_t,
+            parameters=self.parameters,
+        )
+
+        sig = inspect.signature(control_obj.upper_bound)
+        ub_args = {k: pre_state[k] for k in sig.parameters if k in pre_state}
+        ub_value = control_obj.upper_bound(**ub_args)
+
+        return ub_value - controls_t[control_sym]
+
+    def __call__(self, df: Callable, input_grid: Grid) -> torch.Tensor:
         """
         Euler equation loss function using the AiO expectation operator.
 
@@ -559,43 +534,53 @@ class EulerEquationLoss(_EquationLossBase):
         ----------
         df : callable
             Decision function from policy network.
-            Signature: df(states_t, shocks_t, parameters) -> controls_t
         input_grid : Grid
-            Grid containing current states and two independent shock realizations:
-            - {shock_sym}_0: shocks for transitions t → t+1
-            - {shock_sym}_1: shocks for transitions t+1 → t+2 (independent)
+            Grid containing current states and two independent shock realizations.
 
         Returns
         -------
         torch.Tensor
             Weighted squared Euler equation residual.
-            The residual is computed using two independent shock realizations
-            via the AiO expectation operator, then squared and weighted.
-
-        Notes
-        -----
-        The residual f is computed using two independent shock realizations:
-        ε₀ for transitions from t to t+1, and ε₁ for transitions from t+1
-        to t+2 (following Maliar et al. 2021, Definition 2.7). The loss is
-        the squared residual, L = f(ε₀, ε₁)².
         """
         states_t, shocks = self._extract_states_and_shocks(input_grid)
 
-        euler_residual = estimate_euler_residual(
+        if self.constrained:
+            # Compute controls once and share them between the residual
+            # computation and the slack computation so both use the same
+            # autograd graph.
+            shocks_t, _ = _extract_period_shocks(self.bellman_period, shocks)
+            controls_t = self.bellman_period.compute_controls(
+                df, states_t, shocks=shocks_t, parameters=self.parameters
+            )
+
+            euler_residuals = estimate_euler_residual(
+                self.bellman_period,
+                df,
+                states_t,
+                shocks,
+                self.parameters,
+                self.agent,
+                controls_t=controls_t,
+            )
+
+            total = torch.tensor(0.0)
+            for ctrl_sym, residual in euler_residuals.items():
+                slack = self._compute_slack(ctrl_sym, controls_t, states_t, shocks_t)
+                if slack is not None:
+                    total = total + fischer_burmeister(residual, slack) ** 2
+                else:
+                    total = total + torch.relu(-residual) ** 2
+            return self.weight * total
+
+        # Unconstrained loss
+        euler_residuals = estimate_euler_residual(
             self.bellman_period,
-            self.discount_factor,
             df,
             states_t,
             shocks,
             self.parameters,
             self.agent,
         )
-
-        if self.constrained:
-            # One-sided loss for upper-bound constrained controls:
-            # only penalize negative residuals (control exceeding its optimal level).
-            # Positive residuals indicate the constraint is binding, which is optimal
-            # under the Kuhn-Tucker conditions.
-            return self.weight * torch.relu(-euler_residual) ** 2
-
-        return self.weight * euler_residual**2
+        return self.weight * sum(
+            (r**2 for r in euler_residuals.values()), torch.tensor(0.0)
+        )

--- a/src/skagent/loss.py
+++ b/src/skagent/loss.py
@@ -162,6 +162,7 @@ class StaticRewardLoss:
             parameters=self.parameters,
             agent=None,  ## TODO: Pass through the agent?
             shocks=shock_vals,
+            ## Handle multiple decision rules?
         )
         return -r
 
@@ -223,26 +224,11 @@ class EstimatedDiscountedLifetimeRewardLoss:
 
 class _EquationLossBase(ABC):
     """
-    Private base class for losses defined as squared residuals of the
-    Bellman period's optimality conditions.
+    Private base class for Bellman and Euler equation losses.
 
-    Both subclasses (:class:`BellmanEquationLoss`, :class:`EulerEquationLoss`)
-    take input grids that follow the AiO contract from Maliar et al. (2021,
-    Definition 2.7): arrival states plus two independent shock realizations
-    per period, encoded as ``{sym}_0`` (period t) and ``{sym}_1`` (period
-    t+1). The base class:
-
-    - validates that the given agent has at least one reward variable
-      defined in ``bellman_period``;
-    - centralizes storage of ``bellman_period``, ``parameters``, ``agent``,
-      ``arrival_variables``, and ``shock_syms``; and
-    - provides :meth:`_extract_states_and_shocks` to deduplicate
-      grid-extraction logic in subclass ``__call__`` methods.
-
-    Subclasses differ in what optimality condition they evaluate (Bellman
-    residual vs Euler residual), whether they require a value callable, and
-    whether they support inequality constraints; they share the input
-    contract above.
+    Stores shared setup (bellman_period, arrival_variables, shock_syms, reward
+    validation) and provides ``_extract_states_and_shocks`` to avoid duplicate
+    grid-extraction logic in subclass ``__call__`` methods.
     """
 
     def __init__(
@@ -321,16 +307,6 @@ class BellmanEquationLoss(_EquationLossBase):
     where s' = f(s,c,ε) is the next state given current state s, control c, and shock ε,
     and the expectation E_ε' is taken over future shock realizations ε'.
 
-    When ``foc_weight > 0``, the loss includes a first-order condition (FOC) term
-    derived from the Bellman equation (equation 14 of Maliar et al. 2021):
-
-    .. math::
-
-        L = f_{\\text{Bellman}}^2 + v \\cdot f_{\\text{FOC}}^2
-
-    where :math:`f_{\\text{FOC}}` is the FOC residual
-    :math:`u'(c) + \\beta \\, \\partial V(s')/\\partial c = 0`.
-
     This function expects the input grid to contain two independent shock realizations:
     - {shock_sym}_0: shocks for period t (used for immediate reward and transitions)
     - {shock_sym}_1: shocks for period t+1 (used for continuation value evaluation)
@@ -338,21 +314,13 @@ class BellmanEquationLoss(_EquationLossBase):
     Parameters
     ----------
     bellman_period : BellmanPeriod
-        The model block containing dynamics, rewards, and shocks.
-    value_function : dict[str, Callable] | Callable
-        Value function ``vf(states_t, shocks_t, parameters) -> tensor``
-        on arrival states, or a dict mapping agent name to such a
-        callable for multi-agent models. Any pre-decision (iset)
-        computation the underlying approximator needs is the callable's
-        responsibility.
+        The model block containing dynamics, rewards, and shocks
+    value_function : callable
+        A value function that takes state variables and returns value estimates
     parameters : dict, optional
-        Model parameters for calibration.
+        Model parameters for calibration
     agent : str, optional
-        Agent identifier for rewards. Required when ``value_function`` is
-        a dict.
-    foc_weight : float, optional
-        Weight :math:`v` on the FOC residual term (default: 0.0, pure Bellman).
-        Positive values add the FOC loss to improve convergence.
+        Agent identifier for rewards
     """
 
     def __init__(
@@ -390,7 +358,7 @@ class BellmanEquationLoss(_EquationLossBase):
         Returns
         -------
         torch.Tensor
-            Bellman equation residual loss (squared), optionally with FOC term.
+            Bellman equation residual loss (squared)
         """
         states_t, shocks = self._extract_states_and_shocks(input_grid)
 
@@ -512,14 +480,18 @@ class EulerEquationLoss(_EquationLossBase):
             raise ValueError(f"weight must be > 0, got {weight}")
         self.weight = weight
         self.constrained = constrained
-
+        # Cache upper_bound parameter names so _compute_slack does not call
+        # inspect.signature on every forward pass.
+        self._upper_bound_params: dict[str, list[str]] = {}
         if self.constrained:
-            has_upper_bound = any(
-                hasattr(rule, "upper_bound") and rule.upper_bound is not None
-                for rule in bellman_period.block.dynamics.values()
-                if hasattr(rule, "iset")
-            )
-            if not has_upper_bound:
+            for sym, rule in bellman_period.block.dynamics.items():
+                if not hasattr(rule, "iset"):
+                    continue
+                ub = getattr(rule, "upper_bound", None)
+                if ub is None:
+                    continue
+                self._upper_bound_params[sym] = list(inspect.signature(ub).parameters)
+            if not self._upper_bound_params:
                 logger.warning(
                     "constrained=True but no Control in the block has an upper_bound. "
                     "The one-sided loss will use relu(-f)^2 as a fallback. "
@@ -537,20 +509,15 @@ class EulerEquationLoss(_EquationLossBase):
         complementarity condition; see the class-level docstring for the
         scope rationale and the lower-bound follow-up.
         """
-        control_obj = self.bellman_period.block.dynamics.get(control_sym)
-        if (
-            control_obj is None
-            or not hasattr(control_obj, "upper_bound")
-            or control_obj.upper_bound is None
-        ):
+        param_names = self._upper_bound_params.get(control_sym)
+        if param_names is None:
             return None
 
+        control_obj = self.bellman_period.block.dynamics[control_sym]
         pre_state = self.bellman_period.compute_pre_state(
             control_sym, states_t, shocks=shocks_t, parameters=self.parameters
         )
-
-        sig = inspect.signature(control_obj.upper_bound)
-        ub_args = {k: pre_state[k] for k in sig.parameters if k in pre_state}
+        ub_args = {k: pre_state[k] for k in param_names if k in pre_state}
         ub_value = control_obj.upper_bound(**ub_args)
 
         return ub_value - controls_t[control_sym]
@@ -563,13 +530,25 @@ class EulerEquationLoss(_EquationLossBase):
         ----------
         df : callable
             Decision function from policy network.
+            Signature: df(states_t, shocks_t, parameters) -> controls_t
         input_grid : Grid
-            Grid containing current states and two independent shock realizations.
+            Grid containing current states and two independent shock realizations:
+            - {shock_sym}_0: shocks for transitions t → t+1
+            - {shock_sym}_1: shocks for transitions t+1 → t+2 (independent)
 
         Returns
         -------
         torch.Tensor
             Weighted squared Euler equation residual.
+            The residual is computed using two independent shock realizations
+            via the AiO expectation operator, then squared and weighted.
+
+        Notes
+        -----
+        The residual f is computed using two independent shock realizations:
+        ε₀ for transitions from t to t+1, and ε₁ for transitions from t+1
+        to t+2 (following Maliar et al. 2021, Definition 2.7). The loss is
+        the squared residual, L = f(ε₀, ε₁)².
         """
         states_t, shocks = self._extract_states_and_shocks(input_grid)
 

--- a/src/skagent/utils.py
+++ b/src/skagent/utils.py
@@ -110,6 +110,46 @@ def compute_parameter_difference(params1, params2):
     return torch.norm(params1 - params2).item()
 
 
+def fischer_burmeister(
+    a: torch.Tensor, h: torch.Tensor, eps: float = 1e-12
+) -> torch.Tensor:
+    r"""Compute the Fischer-Burmeister function for smooth complementarity.
+
+    The Fischer-Burmeister function replaces the complementarity conditions
+    :math:`a \geq 0,\; h \geq 0,\; ah = 0` with the equivalent smooth equation:
+
+    .. math::
+
+        \text{FB}(a, h) = a + h - \sqrt{a^2 + h^2} = 0
+
+    This is differentiable everywhere, unlike :math:`\min(a, h) = 0`.
+
+    Following Maliar et al. (2021, JME) equation (25).
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        First argument (e.g., slack variable :math:`1 - c/w`).
+    h : torch.Tensor
+        Second argument (e.g., unit-free Lagrange multiplier).
+    eps : float, optional
+        Regularization constant added inside the square root to keep the
+        gradient finite at the origin. At the default ``eps=1e-12``,
+        ``FB(0, 0) = -sqrt(eps) ≈ -1e-6`` rather than exactly zero.
+        This is below typical convergence tolerances but should be
+        accounted for in tests or with very tight tolerances.
+
+    Returns
+    -------
+    torch.Tensor
+        Fischer-Burmeister residual. Approximately zero when the
+        complementarity conditions are satisfied.
+    """
+    if eps <= 0:
+        raise ValueError(f"eps must be > 0, got {eps}")
+    return a + h - torch.sqrt(a**2 + h**2 + eps)
+
+
 def compute_gradients_for_tensors(
     tensors_dict: dict[str, torch.Tensor],
     wrt: dict[str, torch.Tensor],

--- a/tests/test_bellman.py
+++ b/tests/test_bellman.py
@@ -574,55 +574,6 @@ class TestExtractPeriodShocksErrors(unittest.TestCase):
             bellman._extract_period_shocks(self.bp, shocks)
 
 
-class TestFischerBurmeister(unittest.TestCase):
-    """Test the Fischer-Burmeister complementarity function."""
-
-    def test_both_zero(self):
-        """FB(0, 0) = 0."""
-        a = torch.tensor(0.0)
-        h = torch.tensor(0.0)
-        result = bellman.fischer_burmeister(a, h)
-        self.assertAlmostEqual(result.item(), 0.0, places=5)
-
-    def test_complementary_slackness(self):
-        """FB(0, s) ≈ 0 for s > 0 and FB(f, 0) ≈ 0 for f > 0."""
-        # When one is zero and the other is positive, FB should be ≈ 0
-        s = torch.tensor(2.0)
-        result = bellman.fischer_burmeister(torch.tensor(0.0), s)
-        self.assertAlmostEqual(result.item(), 0.0, places=4)
-
-        f = torch.tensor(3.0)
-        result = bellman.fischer_burmeister(f, torch.tensor(0.0))
-        self.assertAlmostEqual(result.item(), 0.0, places=4)
-
-    def test_violation_nonzero(self):
-        """FB(a, h) != 0 when both a > 0 and h > 0."""
-        a = torch.tensor(1.0)
-        h = torch.tensor(1.0)
-        result = bellman.fischer_burmeister(a, h)
-        self.assertNotAlmostEqual(result.item(), 0.0, places=2)
-
-    def test_differentiable(self):
-        """FB is differentiable through autograd."""
-        a = torch.tensor(1.0, requires_grad=True)
-        h = torch.tensor(2.0, requires_grad=True)
-        result = bellman.fischer_burmeister(a, h)
-        result.backward()
-        self.assertIsNotNone(a.grad)
-        self.assertIsNotNone(h.grad)
-        self.assertTrue(torch.isfinite(a.grad))
-        self.assertTrue(torch.isfinite(h.grad))
-
-    def test_differentiable_at_zero(self):
-        """FB gradient is finite near zero due to epsilon safeguard."""
-        a = torch.tensor(0.0, requires_grad=True)
-        h = torch.tensor(0.0, requires_grad=True)
-        result = bellman.fischer_burmeister(a, h)
-        result.backward()
-        self.assertTrue(torch.isfinite(a.grad))
-        self.assertTrue(torch.isfinite(h.grad))
-
-
 class TestEstimateBellmanFocResidual(unittest.TestCase):
     """Test estimate_bellman_foc_residual."""
 
@@ -812,19 +763,3 @@ class TestSingleControlEulerReturnsDict(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertIn("consumption", result)
         self.assertIsInstance(result["consumption"], torch.Tensor)
-
-
-class TestFischerBurmeisterEpsValidation(unittest.TestCase):
-    """Test eps parameter validation."""
-
-    def test_zero_eps_raises(self):
-        a = torch.tensor(1.0)
-        h = torch.tensor(1.0)
-        with self.assertRaises(ValueError, msg="eps must be > 0"):
-            bellman.fischer_burmeister(a, h, eps=0.0)
-
-    def test_negative_eps_raises(self):
-        a = torch.tensor(1.0)
-        h = torch.tensor(1.0)
-        with self.assertRaises(ValueError, msg="eps must be > 0"):
-            bellman.fischer_burmeister(a, h, eps=-1e-12)

--- a/tests/test_bellman.py
+++ b/tests/test_bellman.py
@@ -123,12 +123,10 @@ class TestBellmanPeriodFunctions(unittest.TestCase):
     def test_estimate_bellman_residual(self):
         """Test the Bellman residual helper function."""
 
-        # Create a simple value network with correct interface
-        def simple_value_network(states_t, shocks_t, parameters):
+        def simple_value_function(states_t, shocks_t, parameters):
             wealth = states_t["wealth"]
             return 10.0 * wealth  # Linear value function
 
-        # Create a simple decision function
         def simple_decision_function(states_t, shocks_t, parameters):
             wealth = states_t["wealth"]
             consumption = 0.5 * wealth
@@ -146,10 +144,10 @@ class TestBellmanPeriodFunctions(unittest.TestCase):
         # Estimate Bellman residual
         residual = bellman.estimate_bellman_residual(
             test_bp,
-            simple_value_network,
+            simple_value_function,
             simple_decision_function,
             states_t,
-            shocks,  # Now passing combined shock object,
+            shocks,
         )
 
         # Check that we get a tensor with the right shape

--- a/tests/test_bellman.py
+++ b/tests/test_bellman.py
@@ -14,6 +14,38 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 parameters = {"q": 1.1, "beta": 0.9}
 
+
+def _make_consumption_savings_bp():
+    """Consumption-savings block used by several test classes."""
+    block = model.DBlock(
+        name="consumption_savings",
+        shocks={"income": Normal(mu=1.0, sigma=0.1)},
+        dynamics={
+            "wealth": lambda wealth, income, consumption: wealth + income - consumption,
+            "consumption": model.Control(iset=["wealth"], agent="consumer"),
+            "utility": lambda consumption: torch.log(consumption + 1e-8),
+        },
+        reward={"utility": "consumer"},
+    )
+    block.construct_shocks({})
+    return block, bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+
+
+def _make_multi_control_bp():
+    """Two-control block used by Euler and FOC residual tests."""
+    block = model.DBlock(
+        name="multi_control",
+        dynamics={
+            "c1": model.Control(["a"]),
+            "c2": model.Control(["a"]),
+            "a": lambda a, c1, c2: a - c1 - c2,
+            "u": lambda c1, c2: torch.log(c1 + 1e-8) + torch.log(c2 + 1e-8),
+        },
+        reward={"u": "consumer"},
+    )
+    return block, bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+
+
 block_data = {
     "name": "test block - maliar",
     "dynamics": {
@@ -102,20 +134,7 @@ class TestBellmanPeriodFunctions(unittest.TestCase):
             consumption = 0.5 * wealth
             return {"consumption": consumption}
 
-        # Create a simple test block
-        test_block = model.DBlock(
-            name="test_bellman_residual",
-            shocks={"income": Normal(mu=1.0, sigma=0.1)},
-            dynamics={
-                "wealth": lambda wealth, income, consumption: wealth
-                + income
-                - consumption,
-                "consumption": model.Control(iset=["wealth"], agent="consumer"),
-                "utility": lambda consumption: torch.log(consumption + 1e-8),
-            },
-            reward={"utility": "consumer"},
-        )
-        test_block.construct_shocks({})
+        _, test_bp = _make_consumption_savings_bp()
 
         # Test states and shocks - need combined object with both periods
         states_t = {"wealth": torch.tensor([2.0, 4.0])}
@@ -126,7 +145,7 @@ class TestBellmanPeriodFunctions(unittest.TestCase):
 
         # Estimate Bellman residual
         residual = bellman.estimate_bellman_residual(
-            bellman.BellmanPeriod(test_block, "beta", {"beta": 0.9}),
+            test_bp,
             simple_value_network,
             simple_decision_function,
             states_t,
@@ -238,17 +257,28 @@ class TestGradRewardFunction(unittest.TestCase):
 
         self.shock_bp = bellman.BellmanPeriod(self.shock_block, "beta", {"beta": 0.9})
 
-    def test_get_grad_reward_function_basic(self):
-        """Test basic functionality of get_grad_reward_function."""
-        # Create test inputs with requires_grad=True
+    def _simple_inputs(self):
+        """Create standard (c, a) inputs for the simple block."""
         c = torch.tensor(0.5, requires_grad=True)
         a = torch.tensor(1.0, requires_grad=True)
-
         states_t = {"a": a}
         controls_t = {"c": c}
-        wrt = {"c": c}  # Compute gradient w.r.t. consumption
+        return states_t, controls_t, c, a
 
-        gradients = self.simple_bp.grad_reward_function(states_t, controls_t, wrt)
+    def _multi_reward_inputs(self):
+        """Create standard (c1, c2, w) inputs for the multi-reward block."""
+        c1 = torch.tensor(0.3, requires_grad=True)
+        c2 = torch.tensor(0.2, requires_grad=True)
+        w = torch.tensor(1.0, requires_grad=True)
+        states_t = {"w": w}
+        controls_t = {"c1": c1, "c2": c2}
+        return states_t, controls_t, c1, c2, w
+
+    def test_get_grad_reward_function_basic(self):
+        """Test basic functionality of get_grad_reward_function."""
+        states_t, controls_t, c, a = self._simple_inputs()
+
+        gradients = self.simple_bp.grad_reward_function(states_t, controls_t, {"c": c})
 
         # For u = log(c), du/dc = 1/c = 1/0.5 = 2.0
         expected_grad = 1.0 / c
@@ -259,15 +289,11 @@ class TestGradRewardFunction(unittest.TestCase):
 
     def test_get_grad_reward_function_multiple_variables(self):
         """Test gradients with respect to multiple variables."""
-        # Create test inputs
-        c = torch.tensor(0.5, requires_grad=True)
-        a = torch.tensor(1.0, requires_grad=True)
+        states_t, controls_t, c, a = self._simple_inputs()
 
-        states_t = {"a": a}
-        controls_t = {"c": c}
-        wrt = {"c": c, "a": a}  # Compute gradients w.r.t. both variables
-
-        gradients = self.simple_bp.grad_reward_function(states_t, controls_t, wrt)
+        gradients = self.simple_bp.grad_reward_function(
+            states_t, controls_t, {"c": c, "a": a}
+        )
 
         # For u = log(c), du/dc = 1/c, du/da = 0 (unused variable)
         expected_grad_c = 1.0 / c
@@ -281,16 +307,11 @@ class TestGradRewardFunction(unittest.TestCase):
 
     def test_get_grad_reward_function_multiple_rewards(self):
         """Test gradients for multiple rewards."""
-        # Create test inputs
-        c1 = torch.tensor(0.3, requires_grad=True)
-        c2 = torch.tensor(0.2, requires_grad=True)
-        w = torch.tensor(1.0, requires_grad=True)
+        states_t, controls_t, c1, c2, w = self._multi_reward_inputs()
 
-        states_t = {"w": w}
-        controls_t = {"c1": c1, "c2": c2}
-        wrt = {"c1": c1, "c2": c2}
-
-        gradients = self.multi_reward_bp.grad_reward_function(states_t, controls_t, wrt)
+        gradients = self.multi_reward_bp.grad_reward_function(
+            states_t, controls_t, {"c1": c1, "c2": c2}
+        )
 
         # For u1 = log(c1), du1/dc1 = 1/c1, du1/dc2 = 0
         # For u2 = -0.5*c2^2, du2/dc1 = 0, du2/dc2 = -c2
@@ -312,18 +333,10 @@ class TestGradRewardFunction(unittest.TestCase):
 
     def test_get_grad_reward_function_with_agent_filter(self):
         """Test agent filtering in grad_reward_function."""
-        # Test with agent filter for consumer1 only
-
-        c1 = torch.tensor(0.3, requires_grad=True)
-        c2 = torch.tensor(0.2, requires_grad=True)
-        w = torch.tensor(1.0, requires_grad=True)
-
-        states_t = {"w": w}
-        controls_t = {"c1": c1, "c2": c2}
-        wrt = {"c1": c1}
+        states_t, controls_t, c1, c2, w = self._multi_reward_inputs()
 
         gradients = self.multi_reward_bp.grad_reward_function(
-            states_t, controls_t, wrt, agent="consumer1"
+            states_t, controls_t, {"c1": c1}, agent="consumer1"
         )
 
         # Should only contain u1 (consumer1's reward)
@@ -362,29 +375,6 @@ class TestGradRewardFunction(unittest.TestCase):
         self.assertTrue(
             torch.allclose(gradients["u"]["theta"], expected_grad, atol=1e-6)
         )
-
-    def test_get_grad_reward_function_envelope_condition_example(self):
-        """Test usage pattern for envelope condition in optimization."""
-        # This test demonstrates how the function would be used for envelope conditions
-
-        # Simulate a batch of states and controls
-        batch_size = 3
-        c = torch.tensor([0.3, 0.5, 0.7], requires_grad=True)
-        a = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
-
-        states_t = {"a": a}
-        controls_t = {"c": c}
-        wrt = {"c": c, "a": a}  # Gradients needed for envelope condition
-
-        gradients = self.simple_bp.grad_reward_function(states_t, controls_t, wrt)
-
-        # Check that we get gradients for the full batch
-        self.assertEqual(gradients["u"]["c"].shape, (batch_size,))
-        self.assertIsNone(gradients["u"]["a"])  # u doesn't depend on a
-
-        # For log utility, du/dc = 1/c
-        expected_grad_c = 1.0 / c
-        self.assertTrue(torch.allclose(gradients["u"]["c"], expected_grad_c, atol=1e-6))
 
     def test_get_grad_reward_function_error_handling(self):
         """Test error handling and edge cases."""
@@ -495,44 +485,26 @@ class TestEulerResidualErrorHandling(unittest.TestCase):
         )
         self.bp = bellman.BellmanPeriod(self.block, "beta", {"beta": 0.9})
 
-    def test_callable_discount_factor_raises(self):
-        """Callable discount factor should raise ValueError."""
-
-        def df(s, sh, p):
-            return {"c": s["a"] * 0.5}
-
-        with self.assertRaises(ValueError, msg="State-dependent discount factors"):
-            bellman.estimate_euler_residual(
-                self.bp,
-                lambda x: 0.9,
-                df,
-                {"a": torch.tensor([1.0])},
-                {},
-                {"beta": 0.9},
-            )
-
-    def test_multi_control_raises(self):
-        """Multiple controls should raise NotImplementedError."""
-        multi_block = model.DBlock(
-            name="multi_control",
-            dynamics={
-                "c1": model.Control(["a"]),
-                "c2": model.Control(["a"]),
-                "a": lambda a, c1, c2: a - c1 - c2,
-                "u": lambda c1: torch.log(c1),
-            },
-            reward={"u": "consumer"},
-        )
-        multi_bp = bellman.BellmanPeriod(multi_block, "beta", {"beta": 0.9})
+    def test_multi_control_returns_dict(self):
+        """Multiple controls should return a dict of residuals."""
+        _, multi_bp = _make_multi_control_bp()
 
         def df(s, sh, p):
             a = s["a"]
             return {"c1": a * 0.3, "c2": a * 0.2}
 
-        with self.assertRaises(NotImplementedError, msg="single-control"):
-            bellman.estimate_euler_residual(
-                multi_bp, 0.9, df, {"a": torch.tensor([1.0])}, {}, {"beta": 0.9}
-            )
+        result = bellman.estimate_euler_residual(
+            multi_bp,
+            df,
+            {"a": torch.tensor([1.0])},
+            {},
+            {"beta": 0.9},
+        )
+        self.assertIsInstance(result, dict)
+        self.assertIn("c1", result)
+        self.assertIn("c2", result)
+        for v in result.values():
+            self.assertIsInstance(v, torch.Tensor)
 
 
 class TestComputeControlsTypeError(unittest.TestCase):
@@ -602,6 +574,127 @@ class TestExtractPeriodShocksErrors(unittest.TestCase):
             bellman._extract_period_shocks(self.bp, shocks)
 
 
+class TestFischerBurmeister(unittest.TestCase):
+    """Test the Fischer-Burmeister complementarity function."""
+
+    def test_both_zero(self):
+        """FB(0, 0) = 0."""
+        a = torch.tensor(0.0)
+        h = torch.tensor(0.0)
+        result = bellman.fischer_burmeister(a, h)
+        self.assertAlmostEqual(result.item(), 0.0, places=5)
+
+    def test_complementary_slackness(self):
+        """FB(0, s) ≈ 0 for s > 0 and FB(f, 0) ≈ 0 for f > 0."""
+        # When one is zero and the other is positive, FB should be ≈ 0
+        s = torch.tensor(2.0)
+        result = bellman.fischer_burmeister(torch.tensor(0.0), s)
+        self.assertAlmostEqual(result.item(), 0.0, places=4)
+
+        f = torch.tensor(3.0)
+        result = bellman.fischer_burmeister(f, torch.tensor(0.0))
+        self.assertAlmostEqual(result.item(), 0.0, places=4)
+
+    def test_violation_nonzero(self):
+        """FB(a, h) != 0 when both a > 0 and h > 0."""
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        result = bellman.fischer_burmeister(a, h)
+        self.assertNotAlmostEqual(result.item(), 0.0, places=2)
+
+    def test_differentiable(self):
+        """FB is differentiable through autograd."""
+        a = torch.tensor(1.0, requires_grad=True)
+        h = torch.tensor(2.0, requires_grad=True)
+        result = bellman.fischer_burmeister(a, h)
+        result.backward()
+        self.assertIsNotNone(a.grad)
+        self.assertIsNotNone(h.grad)
+        self.assertTrue(torch.isfinite(a.grad))
+        self.assertTrue(torch.isfinite(h.grad))
+
+    def test_differentiable_at_zero(self):
+        """FB gradient is finite near zero due to epsilon safeguard."""
+        a = torch.tensor(0.0, requires_grad=True)
+        h = torch.tensor(0.0, requires_grad=True)
+        result = bellman.fischer_burmeister(a, h)
+        result.backward()
+        self.assertTrue(torch.isfinite(a.grad))
+        self.assertTrue(torch.isfinite(h.grad))
+
+
+class TestEstimateBellmanFocResidual(unittest.TestCase):
+    """Test estimate_bellman_foc_residual."""
+
+    def setUp(self):
+        self.block, self.bp = _make_consumption_savings_bp()
+
+    def test_returns_finite_tensor_with_correct_shape(self):
+        """FOC residual should match batch size and change with different policies."""
+
+        def value_fn(states, shocks, params):
+            return 10.0 * states["wealth"]
+
+        def decision_fn_half(states, shocks, params):
+            return {"consumption": 0.5 * states["wealth"]}
+
+        def decision_fn_quarter(states, shocks, params):
+            return {"consumption": 0.25 * states["wealth"]}
+
+        states_t = {"wealth": torch.tensor([2.0, 4.0])}
+        shocks = {
+            "income_0": torch.tensor([1.0, 1.0]),
+            "income_1": torch.tensor([1.2, 0.8]),
+        }
+
+        result_half = bellman.estimate_bellman_foc_residual(
+            self.bp, value_fn, decision_fn_half, states_t, shocks
+        )
+        result_quarter = bellman.estimate_bellman_foc_residual(
+            self.bp, value_fn, decision_fn_quarter, states_t, shocks
+        )
+        self.assertIsInstance(result_half, dict)
+        residual_half = next(iter(result_half.values()))
+        residual_quarter = next(iter(result_quarter.values()))
+        self.assertEqual(residual_half.shape, (2,))
+        self.assertTrue(torch.all(torch.isfinite(residual_half)))
+        self.assertTrue(torch.all(torch.isfinite(residual_quarter)))
+        # Different policies should produce different FOC residuals
+        self.assertFalse(
+            torch.allclose(residual_half, residual_quarter),
+            "Different policies should produce different FOC residuals",
+        )
+
+    def test_multi_control_returns_dict(self):
+        """Multi-control model should return a dict of finite residuals per control."""
+        _, multi_bp = _make_multi_control_bp()
+
+        def value_fn(states, shocks, params):
+            return 5.0 * states["a"]
+
+        def df(s, sh, p):
+            return {"c1": s["a"] * 0.3, "c2": s["a"] * 0.2}
+
+        result = bellman.estimate_bellman_foc_residual(
+            multi_bp,
+            value_fn,
+            df,
+            {"a": torch.tensor([1.0, 2.0])},
+            {},
+        )
+        self.assertIsInstance(result, dict)
+        self.assertEqual(set(result.keys()), {"c1", "c2"})
+        for key, residual in result.items():
+            self.assertIsInstance(
+                residual, torch.Tensor, f"residual[{key}] not a tensor"
+            )
+            self.assertEqual(residual.shape, (2,), f"residual[{key}] wrong shape")
+            self.assertTrue(
+                torch.all(torch.isfinite(residual)),
+                f"residual[{key}] contains non-finite values",
+            )
+
+
 class TestEnsureGrad(unittest.TestCase):
     """Test _ensure_grad helper."""
 
@@ -621,3 +714,117 @@ class TestEnsureGrad(unittest.TestCase):
         c = torch.tensor(0.5, requires_grad=False)
         result, controls = bellman._ensure_grad({"c": c}, "c")
         self.assertTrue(result.requires_grad)
+
+
+class TestResolveDiscountFactor(unittest.TestCase):
+    """Test resolve_discount_factor error handling."""
+
+    def test_missing_discount_variable_raises(self):
+        """KeyError when discount variable is not in post dict."""
+        block = model.DBlock(
+            name="test",
+            dynamics={"c": model.Control(["a"]), "a": lambda a, c: a - c},
+            reward={},
+        )
+        bp = bellman.BellmanPeriod(block, "nonexistent_var", {"beta": 0.9})
+        post = {"a": torch.tensor(1.0)}
+
+        with self.assertRaises(KeyError, msg="nonexistent_var"):
+            bp.resolve_discount_factor(post)
+
+    def test_resolves_scalar(self):
+        """Resolves a scalar discount factor from post dict."""
+        block = model.DBlock(
+            name="test",
+            dynamics={"c": model.Control(["a"]), "a": lambda a, c: a - c},
+            reward={},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        post = {"beta": 0.95, "a": torch.tensor(1.0)}
+
+        result = bp.resolve_discount_factor(post)
+        self.assertEqual(result, 0.95)
+
+
+class TestEstimateBellmanResidualNaN(unittest.TestCase):
+    """Test NaN/Inf handling in estimate_bellman_residual."""
+
+    def setUp(self):
+        self.block, self.bp = _make_consumption_savings_bp()
+
+    def test_nan_value_function_raises(self):
+        """ValueError when value function returns NaN."""
+
+        def nan_value_fn(states, shocks, params):
+            return torch.full_like(states["wealth"], float("nan"))
+
+        def df(states, shocks, params):
+            return {"consumption": 0.5 * states["wealth"]}
+
+        states_t = {"wealth": torch.tensor([2.0])}
+        shocks = {
+            "income_0": torch.tensor([1.0]),
+            "income_1": torch.tensor([1.0]),
+        }
+
+        with self.assertRaises(ValueError, msg="NaN or Inf"):
+            bellman.estimate_bellman_residual(
+                self.bp, nan_value_fn, df, states_t, shocks
+            )
+
+    def test_inf_value_function_raises(self):
+        """ValueError when value function returns Inf."""
+
+        def inf_value_fn(states, shocks, params):
+            return torch.full_like(states["wealth"], float("inf"))
+
+        def df(states, shocks, params):
+            return {"consumption": 0.5 * states["wealth"]}
+
+        states_t = {"wealth": torch.tensor([2.0])}
+        shocks = {
+            "income_0": torch.tensor([1.0]),
+            "income_1": torch.tensor([1.0]),
+        }
+
+        with self.assertRaises(ValueError, msg="NaN or Inf"):
+            bellman.estimate_bellman_residual(
+                self.bp, inf_value_fn, df, states_t, shocks
+            )
+
+
+class TestSingleControlEulerReturnsDict(unittest.TestCase):
+    """estimate_euler_residual should always return a dict."""
+
+    def test_single_control_returns_dict(self):
+        _, bp = _make_consumption_savings_bp()
+
+        def df(s, sh, p):
+            return {"consumption": 0.5 * s["wealth"]}
+
+        result = bellman.estimate_euler_residual(
+            bp,
+            df,
+            {"wealth": torch.tensor([2.0])},
+            {"income_0": torch.tensor([1.0]), "income_1": torch.tensor([1.0])},
+            {"beta": 0.9},
+        )
+        self.assertIsInstance(result, dict)
+        self.assertIn("consumption", result)
+        self.assertIsInstance(result["consumption"], torch.Tensor)
+
+
+class TestFischerBurmeisterEpsValidation(unittest.TestCase):
+    """Test eps parameter validation."""
+
+    def test_zero_eps_raises(self):
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        with self.assertRaises(ValueError, msg="eps must be > 0"):
+            bellman.fischer_burmeister(a, h, eps=0.0)
+
+    def test_negative_eps_raises(self):
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        with self.assertRaises(ValueError, msg="eps must be > 0"):
+            bellman.fischer_burmeister(a, h, eps=-1e-12)

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -1,6 +1,5 @@
 from conftest import case_1, case_3, case_4
 import numpy as np
-import os
 import skagent.algos.maliar as maliar
 import skagent.bellman as bellman
 import skagent.grid as grid
@@ -9,7 +8,6 @@ import skagent.block as model
 import torch
 import unittest
 from skagent.distributions import Normal
-from skagent.ann import BlockValueNet
 from skagent.models.benchmarks import (
     get_benchmark_model,
     get_benchmark_calibration,
@@ -82,226 +80,6 @@ class TestGridManipulations(unittest.TestCase):
         full_grid = maliar.generate_givens_from_states(state_grid, block, 2)
 
         self.assertEqual(len(full_grid["psi_0"]), 7)
-
-
-class TestMaliarTrainingLoop(unittest.TestCase):
-    def setUp(self):
-        # Set deterministic state for each test (avoid global state interference in parallel runs)
-        torch.manual_seed(TEST_SEED)
-        np.random.seed(TEST_SEED)
-        # Ensure PyTorch uses deterministic algorithms when possible
-        torch.use_deterministic_algorithms(True, warn_only=True)
-        # Set CUDA deterministic behavior for reproducible tests
-        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-
-    def test_maliar_state_convergence(self):
-        big_t = 2
-
-        # Use deterministic RNG for shock construction
-        rng = np.random.default_rng(TEST_SEED)
-        case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
-        states_0_n = grid.Grid.from_config(
-            {
-                "m": {"min": -20, "max": 20, "count": 9},
-                "g": {"min": -20, "max": 20, "count": 9},
-            }
-        )
-
-        edlrl = loss.EstimatedDiscountedLifetimeRewardLoss(
-            case_4["bp"],
-            big_t,
-            case_4["calibration"],
-        )
-
-        # Use fixed random seed for deterministic training
-        ann, states = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=2,
-            random_seed=TEST_SEED,  # Fixed seed for deterministic training
-            max_iterations=3,
-        )
-
-        sd = states.to_dict()
-
-        # testing for the states converged on the ergodic distribution
-        # note we actual expect these to diverge up to Uniform[-1, 1] shocks.
-        self.assertTrue(torch.allclose(sd["m"], sd["g"], atol=2.5))
-
-    def test_maliar_convergence_tolerance(self):
-        """Test the convergence functionality in the Maliar training loop."""
-        big_t = 2
-
-        # Use deterministic RNG for shock construction
-        rng = np.random.default_rng(TEST_SEED)
-        case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
-        states_0_n = grid.Grid.from_config(
-            {
-                "m": {"min": -10, "max": 10, "count": 5},
-                "g": {"min": -10, "max": 10, "count": 5},
-            }
-        )
-
-        edlrl = loss.EstimatedDiscountedLifetimeRewardLoss(
-            case_4["bp"],
-            big_t,
-            case_4["calibration"],
-        )
-
-        # Test 1: High tolerance (should converge quickly)
-        ann_high_tol, states_high_tol = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=2,
-            random_seed=TEST_SEED,
-            max_iterations=10,
-            tolerance=1e-1,  # High tolerance for quick convergence
-        )
-
-        # Test 2: Low tolerance (should require more iterations or hit max_iterations)
-        ann_low_tol, states_low_tol = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=2,
-            random_seed=TEST_SEED,
-            max_iterations=3,
-            tolerance=1e-8,  # Very low tolerance
-        )
-
-        # Both should return valid networks and states
-        self.assertIsNotNone(ann_high_tol)
-        self.assertIsNotNone(states_high_tol)
-        self.assertIsNotNone(ann_low_tol)
-        self.assertIsNotNone(states_low_tol)
-
-        # Test that tolerance affects convergence behavior
-        # (We can't easily test exact iteration counts due to randomness,
-        # but we can verify the function completes successfully with different tolerances)
-        sd_high = states_high_tol.to_dict()
-        sd_low = states_low_tol.to_dict()
-
-        # Both should produce valid state dictionaries
-        self.assertIn("m", sd_high)
-        self.assertIn("g", sd_high)
-        self.assertIn("m", sd_low)
-        self.assertIn("g", sd_low)
-
-        # Verify states are finite tensors
-        self.assertTrue(torch.all(torch.isfinite(sd_high["m"])))
-        self.assertTrue(torch.all(torch.isfinite(sd_high["g"])))
-        self.assertTrue(torch.all(torch.isfinite(sd_low["m"])))
-        self.assertTrue(torch.all(torch.isfinite(sd_low["g"])))
-
-    def test_maliar_convergence_early_stopping(self):
-        """Test that the training loop can stop early when convergence is achieved."""
-        big_t = 2
-
-        # Use deterministic RNG for shock construction
-        rng = np.random.default_rng(TEST_SEED)
-        case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
-        # Use a smaller grid for faster convergence testing
-        states_0_n = grid.Grid.from_config(
-            {
-                "m": {"min": 0, "max": 5, "count": 3},
-                "g": {"min": 0, "max": 5, "count": 3},
-            }
-        )
-
-        edlrl = loss.EstimatedDiscountedLifetimeRewardLoss(
-            case_4["bp"],
-            big_t,
-            case_4["calibration"],
-        )
-
-        # Test with very high tolerance to ensure early convergence
-        ann, states = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=1,
-            random_seed=TEST_SEED,
-            max_iterations=100,  # Set high max iterations
-            tolerance=1.0,  # Very high tolerance - should converge in 1-2 iterations
-        )
-
-        # Should complete successfully
-        self.assertIsNotNone(ann)
-        self.assertIsNotNone(states)
-
-        # States should be valid
-        sd = states.to_dict()
-        self.assertIn("m", sd)
-        self.assertIn("g", sd)
-        self.assertTrue(torch.all(torch.isfinite(sd["m"])))
-        self.assertTrue(torch.all(torch.isfinite(sd["g"])))
-
-    def test_maliar_convergence_by_loss(self):
-        """Test convergence by both parameter and loss criteria."""
-        big_t = 2
-
-        # Use deterministic RNG for shock construction
-        rng = np.random.default_rng(TEST_SEED)
-        case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
-        # Use a small grid for faster testing
-        states_0_n = grid.Grid.from_config(
-            {
-                "m": {"min": 0, "max": 5, "count": 3},
-                "g": {"min": 0, "max": 5, "count": 3},
-            }
-        )
-
-        edlrl = loss.EstimatedDiscountedLifetimeRewardLoss(
-            case_4["bp"],
-            big_t,
-            case_4["calibration"],
-        )
-
-        # Test 1: Strict tolerance (should require more iterations)
-        ann_strict, states_strict = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=1,
-            random_seed=TEST_SEED,
-            max_iterations=10,
-            tolerance=1e-6,  # Strict tolerance
-        )
-
-        # Test 2: Relaxed tolerance (should converge faster)
-        ann_relaxed, states_relaxed = maliar.maliar_training_loop(
-            case_4["bp"],
-            edlrl,
-            states_0_n,
-            case_4["calibration"],
-            simulation_steps=1,
-            random_seed=TEST_SEED,
-            max_iterations=10,
-            tolerance=1e-1,  # Relaxed tolerance
-        )
-
-        # Both tests should return valid networks and states
-        for ann, states in [(ann_strict, states_strict), (ann_relaxed, states_relaxed)]:
-            self.assertIsNotNone(ann)
-            self.assertIsNotNone(states)
-
-            # States should be valid
-            sd = states.to_dict()
-            self.assertIn("m", sd)
-            self.assertIn("g", sd)
-            self.assertTrue(torch.all(torch.isfinite(sd["m"])))
-            self.assertTrue(torch.all(torch.isfinite(sd["g"])))
 
 
 class TestBellmanLossFunctions(unittest.TestCase):
@@ -383,8 +161,12 @@ class TestBellmanLossFunctions(unittest.TestCase):
             agent="consumer",
         )
         self.assertIn("utility", reward)
-        # Utility can be negative for log(consumption), so just check it's finite
-        self.assertTrue(torch.all(torch.isfinite(reward["utility"])))
+        # u = log(c + 1e-8) for c = [0.5, 1.0]
+        expected_utility = torch.log(controls_t["consumption"] + 1e-8)
+        self.assertTrue(
+            torch.allclose(reward["utility"], expected_utility, atol=1e-6),
+            f"Reward should be log(c). Got {reward['utility']}, expected {expected_utility}",
+        )
 
     def test_bellman_loss_function_error_handling(self):
         """Test error handling in Bellman loss functions."""
@@ -461,33 +243,6 @@ class TestBellmanLossFunctions(unittest.TestCase):
         # Losses should be different for different decision functions
         self.assertFalse(torch.allclose(losses, loss2))
 
-    def test_consistency_with_existing_patterns(self):
-        """Test that the new Bellman loss functions follow existing skagent patterns."""
-
-        # Create a simple value network with correct interface
-        def simple_value_network(states_t, shocks_t, parameters):
-            wealth = states_t["wealth"]
-            return 10.0 * wealth  # Linear value function
-
-        # Test that it works with the training infrastructure
-        loss_function = loss.BellmanEquationLoss(
-            self.bp,
-            simple_value_network,
-            self.parameters,
-        )
-
-        # Test with aggregate_net_loss (from ann.py)
-        from skagent.ann import aggregate_net_loss
-
-        # This should work without errors
-        aggregated_loss = aggregate_net_loss(
-            self.test_grid, self.decision_function, loss_function
-        )
-
-        self.assertIsInstance(aggregated_loss, torch.Tensor)
-        self.assertEqual(aggregated_loss.shape, ())  # Scalar after aggregation
-        self.assertTrue(aggregated_loss >= 0)
-
     def test_shock_independence_in_bellman_residual(self):
         """Test that independent shock realizations produce different results than identical shocks."""
 
@@ -537,54 +292,6 @@ class TestBellmanLossFunctions(unittest.TestCase):
         # Both should be finite
         self.assertTrue(torch.all(torch.isfinite(residual_identical)))
         self.assertTrue(torch.all(torch.isfinite(residual_independent)))
-
-    def test_bellman_loss_with_different_shock_patterns(self):
-        """Test Bellman loss function with various shock patterns."""
-
-        def simple_value_network(states_t, shocks_t, parameters):
-            wealth = states_t["wealth"]
-            income = shocks_t["income"]
-            return (
-                10.0 * wealth + 2.0 * income
-            )  # Value depends on both wealth and income
-
-        loss_function = loss.BellmanEquationLoss(
-            self.bp,
-            simple_value_network,
-            self.parameters,
-        )
-
-        # Test with correlated shocks (period t+1 same as period t)
-        test_grid_correlated = grid.Grid.from_dict(
-            {
-                "wealth": torch.tensor([1.0, 2.0, 3.0]),
-                "income_0": torch.tensor([1.0, 1.2, 0.8]),
-                "income_1": torch.tensor([1.0, 1.2, 0.8]),  # Same as period t
-            }
-        )
-
-        # Test with anti-correlated shocks
-        test_grid_anticorrelated = grid.Grid.from_dict(
-            {
-                "wealth": torch.tensor([1.0, 2.0, 3.0]),
-                "income_0": torch.tensor([1.0, 1.2, 0.8]),
-                "income_1": torch.tensor([1.0, 0.8, 1.2]),  # Opposite of period t
-            }
-        )
-
-        loss_correlated = loss_function(self.decision_function, test_grid_correlated)
-        loss_anticorrelated = loss_function(
-            self.decision_function, test_grid_anticorrelated
-        )
-
-        # Both should produce valid losses
-        self.assertTrue(torch.all(loss_correlated >= 0))
-        self.assertTrue(torch.all(loss_anticorrelated >= 0))
-        self.assertTrue(torch.all(torch.isfinite(loss_correlated)))
-        self.assertTrue(torch.all(torch.isfinite(loss_anticorrelated)))
-
-        # Losses should be different for different shock patterns
-        self.assertFalse(torch.allclose(loss_correlated, loss_anticorrelated))
 
     def test_bellman_residual_error_handling(self):
         """Test error handling in the refactored Bellman residual function."""
@@ -636,9 +343,7 @@ def test_get_euler_residual_loss():
     )
 
     # Create Euler equation loss function
-    loss_fn = loss.EulerEquationLoss(
-        test_bp, discount_factor=d2_calibration["DiscFac"], parameters=d2_calibration
-    )
+    loss_fn = loss.EulerEquationLoss(test_bp, parameters=d2_calibration)
 
     # Test that loss function works with the analytical optimal policy
     losses = loss_fn(d2_policy, input_grid)
@@ -654,542 +359,6 @@ def test_get_euler_residual_loss():
     assert mean_loss < 1e-8, (
         f"Analytical optimal policy should have near-zero Euler loss. Got mean loss: {mean_loss:.6e}"
     )
-
-
-def test_bellman_equation_loss_with_value_network():
-    """Test Bellman equation loss function with separate value network.
-
-    This test verifies that the BellmanEquationLoss class works correctly
-    with a value network. Uses a simple consumption model where the control
-    directly depends on the arrival state (no intermediate dynamics).
-    """
-    # Create a simple test block where control iset matches arrival state
-    # This ensures BlockValueNet can directly use arrival states
-    test_block = model.DBlock(
-        name="test_value_net",
-        shocks={},  # Deterministic for simplicity
-        dynamics={
-            "c": model.Control(iset=["a"], agent="consumer"),
-            "a": lambda a, c: a - c,  # Simple savings transition
-            "u": lambda c: torch.log(c + 1e-8),
-        },
-        reward={"u": "consumer"},
-    )
-    test_block.construct_shocks({})
-
-    test_bp = bellman.BellmanPeriod(test_block, "beta", {"beta": 0.95})
-
-    # Create value network
-    value_net = BlockValueNet(test_bp, width=16)
-
-    # Create input grid with arrival states
-    n_points = 10
-    input_grid = grid.Grid.from_dict(
-        {
-            "a": torch.linspace(1.0, 10.0, n_points),
-        }
-    )
-
-    # Create a simple decision function: consume 30% of assets
-    # This is feasible (c < a) for all a >= 1.0 in our grid
-    def simple_policy(states_t, shocks_t, parameters):
-        a = states_t["a"]
-        return {"c": 0.3 * a}
-
-    # Create loss function
-    loss_fn = loss.BellmanEquationLoss(
-        test_bp, value_net.get_value_function(), parameters=None
-    )
-
-    # Test that loss function works
-    losses = loss_fn(simple_policy, input_grid)
-
-    # Check that we get per-sample losses
-    assert isinstance(losses, torch.Tensor)
-    assert losses.shape[0] == n_points  # One loss per grid point
-    assert torch.all(losses >= 0)  # Squared residuals should be non-negative
-
-
-def test_block_value_net():
-    """Test BlockValueNet functionality."""
-    # Create a test block with multiple state variables
-    test_block = model.DBlock(
-        name="test_multi_state",
-        shocks={"income": Normal(mu=1.0, sigma=0.1)},
-        dynamics={
-            "wealth": lambda wealth, income, consumption: wealth + income - consumption,
-            "capital": lambda capital, investment: capital + investment,
-            "consumption": model.Control(iset=["wealth"], agent="consumer"),
-            "investment": model.Control(iset=["capital"], agent="consumer"),
-            "utility": lambda consumption: torch.log(consumption + 1e-8),
-        },
-        reward={"utility": "consumer"},
-    )
-    test_block.construct_shocks({})
-
-    test_bp = bellman.BellmanPeriod(test_block, "beta", {"beta": 0.95})
-
-    # Create value network - now takes block instead of state_variables
-    value_net = BlockValueNet(test_bp, width=16)
-
-    # Test value function computation
-    states_t = {"wealth": torch.tensor([1.0, 2.0, 3.0])}
-    shocks_t = {"income": torch.tensor([1.0, 1.0, 1.0])}
-
-    values = value_net.value_function(states_t, shocks_t, {})
-
-    # Check output shape and type
-    assert isinstance(values, torch.Tensor)
-    assert values.shape == (3,)
-
-    # Test get_value_function method
-    vf = value_net.get_value_function()
-    values2 = vf(states_t, shocks_t, {})
-
-    # Should give same results
-    assert torch.allclose(values, values2)
-
-
-class TestEulerResidualsBenchmarks(unittest.TestCase):
-    """
-    Test Euler residuals using consumption-saving models.
-
-    These tests verify that the Euler equation residual computation works correctly
-    and produces sensible results for various model specifications. The tests follow
-    the methodology described in Maliar, Maliar, and Winant (2021, JME) for testing
-    first-order conditions.
-    """
-
-    def test_euler_residual_d2_optimal_policy(self):
-        """
-        Test that the analytical optimal policy achieves near-zero Euler residual.
-
-        D-2 is the infinite horizon CRRA perfect foresight model.
-        The analytical solution is: c_t = κ*W_t where κ = (R - (βR)^(1/σ))/R
-        and W_t = m_t + H_t is total wealth (cash-on-hand plus human wealth H_t = y/r).
-
-        The Euler equation is: u'(c_t) = β*R*u'(c_{t+1})
-        For the optimal policy, the Euler residual should be essentially zero,
-        validating that estimate_euler_residual correctly implements the FOC.
-        """
-        # Get D-2 benchmark model and calibration
-        d2_block = get_benchmark_model("D-2")
-        d2_calibration = get_benchmark_calibration("D-2")
-        d2_policy = get_analytical_policy("D-2")
-
-        # Construct shocks for the block (needed even though D-2 is deterministic)
-        d2_block.construct_shocks(d2_calibration)
-
-        # Create BellmanPeriod
-        bp = bellman.BellmanPeriod(d2_block, "DiscFac", d2_calibration)
-
-        # Create test states
-        n_samples = 100
-        test_states = {"a": torch.linspace(0.1, 10.0, n_samples)}
-        shocks = {}
-
-        # Compute Euler residual with analytical optimal policy
-        optimal_residual = bellman.estimate_euler_residual(
-            bp,
-            d2_calibration["DiscFac"],
-            d2_policy,
-            test_states,
-            shocks,
-            d2_calibration,
-        )
-
-        # For optimal policy, residual should be essentially zero (machine precision)
-        mean_residual = torch.mean(torch.abs(optimal_residual)).item()
-        mse_residual = torch.mean(optimal_residual**2).item()
-
-        # Tolerance accounts for numerical precision in autograd
-        assert mean_residual < 1e-5, (
-            f"Analytical optimal policy should have near-zero Euler residual. "
-            f"Got mean |residual| = {mean_residual:.6e}"
-        )
-
-        assert mse_residual < 1e-10, (
-            f"Analytical optimal policy should have near-zero Euler MSE. "
-            f"Got MSE = {mse_residual:.6e}"
-        )
-
-    def test_euler_equation_training(self):
-        """
-        Test that a policy can be trained via Euler equation loss to achieve near-zero residual.
-
-        This is the key validation test for the Maliar et al. (2021) methodology:
-        train a neural network policy by minimizing squared Euler residuals,
-        and verify the trained policy satisfies the first-order conditions.
-
-        Uses scikit-agent's BlockPolicyNet and train_block_nn for proper integration.
-        """
-        from skagent.ann import BlockPolicyNet, train_block_nn
-
-        # Get D-2 benchmark model and calibration
-        d2_block = get_benchmark_model("D-2")
-        d2_calibration = get_benchmark_calibration("D-2")
-
-        # Construct shocks for the block
-        d2_block.construct_shocks(d2_calibration)
-
-        # Create BellmanPeriod
-        bp = bellman.BellmanPeriod(d2_block, "DiscFac", d2_calibration)
-
-        # Create policy network using scikit-agent's BlockPolicyNet
-        torch.manual_seed(TEST_SEED)
-        policy_net = BlockPolicyNet(bp, width=32, init_seed=TEST_SEED)
-
-        # Create Euler equation loss
-        euler_loss_fn = loss.EulerEquationLoss(
-            bp, discount_factor=d2_calibration["DiscFac"], parameters=d2_calibration
-        )
-
-        # Create training grid with states (D-2 is deterministic, no shocks needed)
-        n_grid_points = 64
-        train_grid = grid.Grid.from_dict(
-            {
-                "a": torch.rand(n_grid_points, device=device) * 9.9
-                + 0.1,  # a in [0.1, 10]
-            }
-        )
-
-        # Train using scikit-agent's train_block_nn
-        trained_net, final_loss = train_block_nn(
-            policy_net, train_grid, euler_loss_fn, epochs=300
-        )
-
-        # Verify training achieved small loss
-        assert final_loss < 0.01, (
-            f"Training should achieve small Euler loss. Got final loss: {final_loss:.6e}"
-        )
-
-        # Evaluate on test grid using the trained policy
-        test_states = {"a": torch.linspace(0.1, 10.0, 100, device=device)}
-        shocks = {}
-
-        # Get decision function from trained network
-        decision_fn = trained_net.get_decision_function()
-
-        # Compute final Euler residual
-        final_residual = bellman.estimate_euler_residual(
-            bp,
-            d2_calibration["DiscFac"],
-            decision_fn,
-            test_states,
-            shocks,
-            d2_calibration,
-        )
-        final_residual = final_residual.detach()
-
-        # The trained policy should achieve small Euler residual
-        mean_residual = torch.mean(torch.abs(final_residual)).item()
-        mse_residual = torch.mean(final_residual**2).item()
-
-        # Tolerance: trained policy should have mean |residual| < 0.1
-        # (Training loss was ~0.0002, but evaluation on different grid points may be higher)
-        assert mean_residual < 0.1, (
-            f"Trained policy should have small Euler residual. "
-            f"Got mean |residual| = {mean_residual:.6e}"
-        )
-
-        # Verify MSE is reasonably small (< 0.05)
-        assert mse_residual < 0.05, (
-            f"Trained policy should have small Euler residual MSE. "
-            f"Got MSE = {mse_residual:.6e}"
-        )
-
-    def test_maliar_training_loop_u2_analytical(self):
-        """
-        Test maliar_training_loop with U-2 model against analytical PIH solution.
-
-        U-2 uses NORMALIZED variables (all divided by permanent income P):
-        - a = A/P (normalized assets, arrival state)
-        - m = M/P = R*a/ψ + 1 (normalized cash-on-hand)
-        - c = C/P (normalized consumption)
-
-        Analytical solution: c = (1-β)(m + 1/r) where 1/r is normalized human wealth.
-        """
-        # Get U-2 benchmark model (unconstrained PIH - upper bound is non-binding,
-        # so constrained=False is appropriate). See future gallery page for details.
-        u2_block = get_benchmark_model("U-2")
-        u2_calibration = get_benchmark_calibration("U-2")
-        analytical_policy = get_analytical_policy("U-2")
-
-        # Construct shocks for the block
-        rng = np.random.default_rng(TEST_SEED)
-        u2_block.construct_shocks(u2_calibration, rng=rng)
-
-        # Create BellmanPeriod
-        bp = bellman.BellmanPeriod(u2_block, "DiscFac", u2_calibration)
-
-        # Create initial states grid (normalized assets)
-        states_0_n = grid.Grid.from_config(
-            {
-                "a": {"min": 0.5, "max": 5.0, "count": 15},
-            }
-        )
-
-        # Create Euler equation loss
-        # Note: after PR #168, discount_factor will come from BellmanPeriod
-        euler_loss_fn = loss.EulerEquationLoss(
-            bp,
-            discount_factor=u2_calibration["DiscFac"],
-            parameters=u2_calibration,
-        )
-
-        # Train the policy
-        trained_net, final_states = maliar.maliar_training_loop(
-            bp,
-            euler_loss_fn,
-            states_0_n,
-            u2_calibration,
-            shock_copies=2,
-            max_iterations=12,
-            tolerance=1e-6,
-            random_seed=TEST_SEED,
-            simulation_steps=1,
-        )
-
-        # Verify training completed
-        self.assertIsNotNone(trained_net)
-
-        # Get decision functions
-        decision_fn = trained_net.get_decision_function()
-
-        # Test on grid within training range (normalized assets)
-        n_test = 25
-        test_a = torch.linspace(0.5, 5.0, n_test, device=device)
-        test_states = {"a": test_a}
-        test_shocks = {"psi": torch.ones(n_test, device=device)}
-
-        # Get trained and analytical consumption (both normalized)
-        trained_c = decision_fn(test_states, test_shocks, u2_calibration)["c"]
-        analytical_c = analytical_policy(test_states, test_shocks, u2_calibration)["c"]
-
-        # Compare trained vs analytical
-        rel_error = torch.abs(trained_c - analytical_c) / (analytical_c + 1e-8)
-        mean_rel_error = rel_error.mean().item()
-
-        # Trained policy should be reasonably close to analytical (within 15%).
-        # Note: with CRRA utility, the Euler equation pins down both the shape and
-        # the level of the optimal consumption policy; arbitrary rescalings k * c*
-        # do NOT satisfy the Euler equation unless k = 1. The 15% tolerance here
-        # reflects numerical approximation error (finite training iterations,
-        # stochastic optimization, and function-approximation error), not any
-        # theoretical indeterminacy in the Euler condition.
-        self.assertLess(
-            mean_rel_error,
-            0.15,
-            f"Trained policy should approximately match analytical PIH solution. "
-            f"Mean relative error: {mean_rel_error:.4f}",
-        )
-
-    def test_maliar_training_loop_u3_buffer_stock(self):
-        """
-        Test maliar_training_loop with U-3 buffer stock model (CRRA=2, with constraint).
-
-        U-3 uses NORMALIZED variables (all divided by permanent income P):
-        - a = A/P (normalized assets, arrival state)
-        - m = M/P = R*a/ψ + θ (normalized cash-on-hand)
-        - c = C/P (normalized consumption)
-
-        This model does NOT have a closed-form solution due to the borrowing
-        constraint + income uncertainty interaction. We validate the trained
-        policy using:
-        1. Basic sanity checks (positive consumption, budget constraint)
-        2. Monotonicity in wealth
-        3. Euler residual near zero in non-constrained region (high wealth)
-        4. Limiting MPC approaching perfect foresight value at high wealth
-        """
-        # Get U-3 buffer stock model (CRRA=2, with borrowing constraint)
-        u3_block = get_benchmark_model("U-3")
-        u3_calibration = get_benchmark_calibration("U-3")
-
-        # Construct shocks for the block
-        rng = np.random.default_rng(TEST_SEED)
-        u3_block.construct_shocks(u3_calibration, rng=rng)
-
-        # Create BellmanPeriod
-        bp = bellman.BellmanPeriod(u3_block, "DiscFac", u3_calibration)
-
-        # Create initial states grid (normalized assets)
-        # Use wider range to test both constrained and unconstrained regions
-        states_0_n = grid.Grid.from_config(
-            {
-                "a": {"min": 0.5, "max": 10.0, "count": 25},
-            }
-        )
-
-        # Create Euler equation loss with constrained=True for buffer stock model
-        # The borrowing constraint (c <= m) means the Euler equation becomes an
-        # inequality at constrained points: u'(c) >= βR E[u'(c')].
-        # Using constrained=True enables one-sided loss that only penalizes
-        # negative residuals (overconsumption), not positive ones (constraint binding).
-        euler_loss_fn = loss.EulerEquationLoss(
-            bp,
-            discount_factor=u3_calibration["DiscFac"],
-            parameters=u3_calibration,
-            constrained=True,  # Key fix: use one-sided loss for borrowing constraint
-        )
-
-        # Train the policy with more iterations for better convergence
-        trained_net, final_states = maliar.maliar_training_loop(
-            bp,
-            euler_loss_fn,
-            states_0_n,
-            u3_calibration,
-            shock_copies=2,
-            max_iterations=15,
-            tolerance=1e-6,
-            random_seed=TEST_SEED,
-            simulation_steps=1,
-        )
-
-        # Verify training completed
-        self.assertIsNotNone(trained_net)
-        self.assertIsNotNone(final_states)
-
-        # Get decision function and parameters
-        decision_fn = trained_net.get_decision_function()
-        R = u3_calibration["R"]
-        beta = u3_calibration["DiscFac"]  # β ≡ DiscFac (standard economics notation)
-        gamma = u3_calibration["CRRA"]
-
-        # =================================================================
-        # 1. Basic sanity checks
-        # =================================================================
-        n_test = 30
-        test_a = torch.linspace(0.5, 10.0, n_test, device=device)
-        test_states = {"a": test_a}
-        test_shocks = {
-            "psi": torch.ones(n_test, device=device),
-            "theta": torch.ones(n_test, device=device),
-        }
-
-        trained_c = decision_fn(test_states, test_shocks, u3_calibration)["c"]
-
-        # Consumption should be positive
-        self.assertTrue(
-            torch.all(trained_c > 0), "Trained consumption should be positive"
-        )
-
-        # Consumption should respect budget constraint (c <= m)
-        expected_m = R * test_a + 1  # m = R*a/psi + theta when psi=theta=1
-        self.assertTrue(
-            torch.all(trained_c <= expected_m + 1e-6),
-            "Trained consumption should respect budget constraint (c <= m)",
-        )
-
-        # =================================================================
-        # 2. Monotonicity check (overall trend)
-        # For neural network approximation, we allow minor violations but
-        # ensure the overall trend is strongly increasing.
-        # =================================================================
-        c_diff = trained_c[1:] - trained_c[:-1]
-
-        # Overall consumption at high wealth should be much larger than at low wealth
-        c_range = trained_c[-1] - trained_c[0]
-        self.assertGreater(
-            c_range.item(),
-            0.5,
-            f"Consumption should increase substantially over wealth range. "
-            f"Got c(high) - c(low) = {c_range.item():.4f}",
-        )
-
-        # Most differences should be positive (allow up to 10% violations for NN noise)
-        positive_diffs = torch.sum(c_diff > 0).item()
-        total_diffs = len(c_diff)
-        positive_ratio = positive_diffs / total_diffs
-        self.assertGreater(
-            positive_ratio,
-            0.9,
-            f"At least 90% of consumption differences should be positive. "
-            f"Got {positive_ratio:.2%} ({positive_diffs}/{total_diffs}). "
-            f"100% is unrealistic for NN approximations due to local non-monotonicity.",
-        )
-
-        # =================================================================
-        # 3. Euler residual check in non-constrained region (high wealth)
-        # At high wealth, the borrowing constraint is slack and Euler
-        # equation should be satisfied exactly.
-        # =================================================================
-        # Test at high wealth where constraint is not binding
-        n_high = 10
-        high_wealth_a = torch.linspace(5.0, 10.0, n_high, device=device)
-        high_wealth_states = {"a": high_wealth_a}
-
-        # Provide shocks in _0/_1 format for estimate_euler_residual
-        high_wealth_shocks = {
-            "psi_0": torch.ones(n_high, device=device),
-            "psi_1": torch.ones(n_high, device=device),
-            "theta_0": torch.ones(n_high, device=device),
-            "theta_1": torch.ones(n_high, device=device),
-        }
-
-        euler_residual = bellman.estimate_euler_residual(
-            bp,
-            beta,
-            decision_fn,
-            high_wealth_states,
-            high_wealth_shocks,
-            u3_calibration,
-        )
-
-        mean_euler_residual = torch.mean(torch.abs(euler_residual)).item()
-        # In the unconstrained region, Euler residual should be small
-        self.assertLess(
-            mean_euler_residual,
-            0.3,
-            f"Euler residual should be small at high wealth (unconstrained). "
-            f"Got mean |residual| = {mean_euler_residual:.4f}",
-        )
-
-        # =================================================================
-        # 4. Limiting MPC check (informational)
-        # As wealth -> infinity, MPC -> kappa_pf = (R - (beta*R)^(1/gamma)) / R
-        # With limited training iterations, the policy may not fully converge.
-        # We verify MPC is in a reasonable range (positive, less than 1).
-        # =================================================================
-        kappa_pf = (R - (beta * R) ** (1 / gamma)) / R
-
-        # Compute MPC numerically at high wealth
-        delta_a = 0.5
-        high_a = torch.tensor([8.0, 9.0, 10.0], device=device)
-        high_states = {"a": high_a}
-        high_shocks = {
-            "psi": torch.ones(3, device=device),
-            "theta": torch.ones(3, device=device),
-        }
-
-        c_high = decision_fn(high_states, high_shocks, u3_calibration)["c"]
-        c_high_plus = decision_fn({"a": high_a + delta_a}, high_shocks, u3_calibration)[
-            "c"
-        ]
-
-        # MPC = dc/dm, and dm/da = R (when psi=1)
-        delta_m = R * delta_a
-        mpc_high = ((c_high_plus - c_high) / delta_m).mean().item()
-
-        # Log the limiting MPC for informational purposes
-        print(
-            f"\nLimiting MPC check: computed = {mpc_high:.4f}, "
-            f"perfect foresight = {kappa_pf:.4f}"
-        )
-
-        # MPC should be strictly between 0 and 1 for a valid consumption function.
-        # With the constrained=True Euler loss, training should converge to
-        # economically sensible policies. We use tight bounds (0.0, 1.0) that
-        # reflect the theoretical requirement for buffer stock models.
-        self.assertGreater(
-            mpc_high,
-            0.0,  # MPC must be positive (saving decreases with wealth)
-            f"MPC should be positive at high wealth. Got MPC = {mpc_high:.4f}",
-        )
-        self.assertLess(
-            mpc_high,
-            1.0,  # MPC must be less than 1 (some saving at high wealth)
-            f"MPC should be less than 1 at high wealth. Got MPC = {mpc_high:.4f}",
-        )
 
 
 class TestOneSidedEulerLoss(unittest.TestCase):
@@ -1232,40 +401,6 @@ class TestOneSidedEulerLoss(unittest.TestCase):
             torch.allclose(constrained_loss_mixed, expected_mixed, atol=1e-6),
             f"Mixed residuals not handled correctly. "
             f"Got: {constrained_loss_mixed}, expected: {expected_mixed}",
-        )
-
-    def test_one_sided_vs_two_sided_loss(self):
-        """Test that one-sided loss differs from two-sided loss appropriately."""
-        # Two-sided loss always penalizes deviation from zero
-        residuals = torch.tensor([0.5, -0.3, 1.0, -0.8])
-
-        two_sided_loss = residuals**2
-        one_sided_loss = torch.relu(-residuals) ** 2
-
-        # For positive residuals, one-sided should be less than two-sided
-        self.assertLess(
-            one_sided_loss[0].item(),
-            two_sided_loss[0].item(),
-            "One-sided loss should be less than two-sided for positive residual",
-        )
-        self.assertLess(
-            one_sided_loss[2].item(),
-            two_sided_loss[2].item(),
-            "One-sided loss should be less than two-sided for positive residual",
-        )
-
-        # For negative residuals, one-sided should equal two-sided
-        self.assertAlmostEqual(
-            one_sided_loss[1].item(),
-            two_sided_loss[1].item(),
-            places=6,
-            msg="One-sided loss should equal two-sided for negative residual",
-        )
-        self.assertAlmostEqual(
-            one_sided_loss[3].item(),
-            two_sided_loss[3].item(),
-            places=6,
-            msg="One-sided loss should equal two-sided for negative residual",
         )
 
 
@@ -1349,13 +484,11 @@ class TestEulerLossConstrainedIntegration(unittest.TestCase):
         # Create loss functions with both settings
         loss_unconstrained = loss.EulerEquationLoss(
             bp,
-            discount_factor=u3_calibration["DiscFac"],
             parameters=u3_calibration,
             constrained=False,
         )
         loss_constrained = loss.EulerEquationLoss(
             bp,
-            discount_factor=u3_calibration["DiscFac"],
             parameters=u3_calibration,
             constrained=True,
         )
@@ -1391,169 +524,39 @@ class TestEulerLossConstrainedIntegration(unittest.TestCase):
         self.assertIsInstance(constrained_loss, torch.Tensor)
         self.assertEqual(unconstrained_loss.shape, constrained_loss.shape)
 
-        # Constrained loss should be <= unconstrained loss (it ignores positive residuals)
-        self.assertLessEqual(
-            constrained_loss.mean().item(),
-            unconstrained_loss.mean().item() + 1e-6,  # Small tolerance for numerical
-            "Constrained loss should be <= unconstrained loss (ignores positive residuals)",
+        # Both losses should be finite and non-negative
+        self.assertTrue(
+            torch.isfinite(unconstrained_loss).all(),
+            "Unconstrained loss should be finite",
         )
-
-    def test_constrained_loss_zero_for_binding_constraint(self):
-        """Test that constrained loss is zero when constraint binds (positive residual).
-
-        At very low wealth, the borrowing constraint binds and the Euler residual
-        is positive (u'(c) > βR E[u'(c')]). The one-sided loss should be zero.
-        """
-        # Use U-3 buffer stock model
-        u3_block = get_benchmark_model("U-3")
-        u3_calibration = get_benchmark_calibration("U-3")
-
-        bp = bellman.BellmanPeriod(u3_block, "DiscFac", u3_calibration)
-
-        loss_constrained = loss.EulerEquationLoss(
-            bp,
-            discount_factor=u3_calibration["DiscFac"],
-            parameters=u3_calibration,
-            constrained=True,
-        )
-
-        # Create grid at very low wealth where constraint binds
-        low_wealth_grid = grid.Grid.from_config(
-            {
-                "a": {"min": 0.01, "max": 0.1, "count": 5},
-                "psi_0": {"min": 1.0, "max": 1.0, "count": 5},
-                "psi_1": {"min": 1.0, "max": 1.0, "count": 5},
-                "theta_0": {"min": 1.0, "max": 1.0, "count": 5},
-                "theta_1": {"min": 1.0, "max": 1.0, "count": 5},
-            }
-        )
-
-        # Create policy that consumes all available resources (constraint binding)
-        def constrained_policy(states, shocks, parameters):
-            R = parameters["R"]
-            a = states["a"]
-            psi = shocks.get("psi", torch.ones_like(a))
-            theta = shocks.get("theta", torch.ones_like(a))
-            m = R * a / psi + theta
-            # Consume exactly m (constraint binds: c = m)
-            c = m * 0.99  # Just under m to stay feasible
-            return {"c": c}
-
-        # Compute constrained loss
-        constrained_loss = loss_constrained(constrained_policy, low_wealth_grid)
-
-        # Loss should be finite (not NaN or Inf)
         self.assertTrue(
             torch.isfinite(constrained_loss).all(),
-            f"Constrained loss should be finite, got {constrained_loss}",
+            "Constrained loss (Fischer-Burmeister) should be finite",
+        )
+        self.assertGreaterEqual(
+            constrained_loss.mean().item(),
+            0.0,
+            "Constrained loss should be non-negative",
         )
 
-
-class TestU3ConstrainedRegionBehavior(unittest.TestCase):
-    """Test U-3 buffer stock model behavior in the constrained region (low wealth)."""
-
-    def test_u3_positive_euler_residual_at_low_wealth(self):
-        """Test that trained U-3 policy has positive Euler residuals at low wealth.
-
-        At low wealth where the borrowing constraint binds, the Euler equation
-        becomes an inequality: u'(c) >= βR E[u'(c')].
-        This means the Euler residual f = u'(c) - βR E[u'(c')] should be positive.
-        """
-        torch.manual_seed(TEST_SEED)
-
-        # Get U-3 model components
-        u3_block = get_benchmark_model("U-3")
-        u3_calibration = get_benchmark_calibration("U-3")
-
-        # Construct shocks for the block
-        rng = np.random.default_rng(TEST_SEED)
-        u3_block.construct_shocks(u3_calibration, rng=rng)
-
-        bp = bellman.BellmanPeriod(u3_block, "DiscFac", u3_calibration)
-
-        # Create initial states grid focused on LOW wealth (constrained region)
-        states_0_n = grid.Grid.from_config(
-            {
-                "a": {"min": 0.1, "max": 1.0, "count": 15},
-            }
+        # Constrained (Fischer-Burmeister) and unconstrained (squared residual)
+        # use different formulations, so they should produce different losses
+        # for the same suboptimal policy
+        self.assertFalse(
+            torch.allclose(unconstrained_loss, constrained_loss),
+            "Constrained and unconstrained losses should differ "
+            "(Fischer-Burmeister vs squared residual)",
         )
-
-        # Create Euler equation loss with constrained=True
-        euler_loss_fn = loss.EulerEquationLoss(
-            bp,
-            discount_factor=u3_calibration["DiscFac"],
-            parameters=u3_calibration,
-            constrained=True,
+        # Both should be strictly positive for a suboptimal policy
+        self.assertGreater(
+            unconstrained_loss.mean().item(),
+            1e-8,
+            "Unconstrained loss should be positive for suboptimal policy",
         )
-
-        # Train the policy
-        trained_net, final_states = maliar.maliar_training_loop(
-            bp,
-            euler_loss_fn,
-            states_0_n,
-            u3_calibration,
-            shock_copies=2,
-            max_iterations=15,
-            tolerance=1e-6,
-            random_seed=TEST_SEED,
-            simulation_steps=1,
-        )
-
-        # Create decision function from trained network
-        decision_fn = trained_net.get_decision_function()
-
-        # Test at very low wealth points where constraint should bind
-        low_wealth_states = {"a": torch.tensor([0.05, 0.1, 0.2], device=device)}
-        low_wealth_shocks = {
-            "psi": torch.ones(3, device=device),
-            "theta": torch.ones(3, device=device),
-        }
-
-        # Get consumption
-        result = decision_fn(low_wealth_states, low_wealth_shocks, u3_calibration)
-        c = result["c"]
-
-        # Compute m at these states
-        R = u3_calibration["R"]
-        m = (
-            R * low_wealth_states["a"] / low_wealth_shocks["psi"]
-            + low_wealth_shocks["theta"]
-        )
-
-        # Verify basic properties of the trained policy at low wealth:
-        # 1. Consumption is positive
-        # 2. Consumption respects the borrowing constraint (c <= m)
-        # 3. Consumption is a non-trivial fraction of m (not near-zero)
-        #
-        # Note: We don't require c to be very close to m because:
-        # - The one-sided loss allows positive residuals (under-consumption)
-        # - With limited training iterations, the policy may not be optimal
-        # - The key test is that training with constrained=True produces valid output
-
-        # Consumption should be positive
-        self.assertTrue(
-            torch.all(c > 0),
-            f"Consumption should be positive. Got c = {c}",
-        )
-
-        # Consumption should respect borrowing constraint (c <= m)
-        self.assertTrue(
-            torch.all(c <= m + 1e-6),
-            f"Consumption should respect borrowing constraint c <= m. "
-            f"Got c = {c}, m = {m}",
-        )
-
-        # Consumption should be a meaningful fraction of resources (not degenerate)
-        consumption_ratio = c / m
-        self.assertTrue(
-            torch.all(consumption_ratio > 0.1),
-            f"Consumption should be a meaningful fraction of m (not degenerate). "
-            f"Got c/m = {consumption_ratio}, c = {c}, m = {m}",
-        )
-        self.assertTrue(
-            torch.all(consumption_ratio < 1.0),
-            f"Consumption ratio should be < 1.0 (respecting constraint). "
-            f"Got c/m = {consumption_ratio}",
+        self.assertGreater(
+            constrained_loss.mean().item(),
+            1e-8,
+            "Constrained loss should be positive for suboptimal policy",
         )
 
 
@@ -1583,7 +586,6 @@ class TestConstrainedWarning(unittest.TestCase):
         with self.assertLogs("skagent.loss", level=logging.WARNING) as cm:
             loss.EulerEquationLoss(
                 bp,
-                discount_factor=calibration["DiscFac"],
                 parameters=calibration,
                 constrained=True,
             )
@@ -1605,7 +607,6 @@ class TestConstrainedWarning(unittest.TestCase):
         with self.assertNoLogs(logger, level=logging.WARNING):
             loss.EulerEquationLoss(
                 bp,
-                discount_factor=u3_calibration["DiscFac"],
                 parameters=u3_calibration,
                 constrained=True,
             )
@@ -1643,195 +644,189 @@ class TestSimulateForwardValidation(unittest.TestCase):
         self.assertTrue(torch.allclose(result["m"], torch.tensor([1.0, 2.0])))
 
 
-class TestMaliarTrainingLoopValidation(unittest.TestCase):
-    """Test input validation in maliar_training_loop."""
+class TestSimulateForwardHappyPath(unittest.TestCase):
+    """Test simulate_forward simulation loop for big_t >= 1."""
 
     def setUp(self):
-        torch.manual_seed(TEST_SEED)
-        np.random.seed(TEST_SEED)
-
         rng = np.random.default_rng(TEST_SEED)
         case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
         self.bp = case_4["bp"]
-        self.states = grid.Grid.from_config(
-            {
-                "m": {"min": 0, "max": 5, "count": 3},
-                "g": {"min": 0, "max": 5, "count": 3},
-            }
-        )
-        self.loss_fn = loss.EstimatedDiscountedLifetimeRewardLoss(
-            self.bp, 2, case_4["calibration"]
-        )
-        self.calibration = case_4["calibration"]
+        # case_4 Control(["g", "m"]) — policy returns c given g, m
+        self.policy = lambda s, sh, p: {"c": s["m"] * 0.5 + s["g"] * 0.0}
+        self.states = {
+            "m": torch.tensor([1.0, 2.0, 3.0]),
+            "g": torch.tensor([0.5, 0.5, 0.5]),
+        }
 
-    def test_max_iterations_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                max_iterations=0,
-                random_seed=TEST_SEED,
-            )
+    def test_big_t_one_returns_dict_with_same_keys(self):
+        """simulate_forward with big_t=1 returns a dict with the same state keys."""
+        result = maliar.simulate_forward(self.states, self.bp, self.policy, {}, big_t=1)
+        self.assertIsInstance(result, dict)
+        self.assertIn("m", result)
+        self.assertIn("g", result)
 
-    def test_max_iterations_negative_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                max_iterations=-5,
-                random_seed=TEST_SEED,
-            )
-
-    def test_tolerance_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                tolerance=0,
-                random_seed=TEST_SEED,
-            )
-
-    def test_tolerance_negative_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                tolerance=-1e-6,
-                random_seed=TEST_SEED,
-            )
-
-    def test_shock_copies_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                shock_copies=0,
-                random_seed=TEST_SEED,
-            )
-
-    def test_simulation_steps_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                simulation_steps=0,
-                random_seed=TEST_SEED,
-            )
-
-    def test_network_width_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                network_width=0,
-                random_seed=TEST_SEED,
-            )
-
-    def test_epochs_per_iteration_zero_raises(self):
-        with self.assertRaises(ValueError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                epochs_per_iteration=0,
-                random_seed=TEST_SEED,
-            )
-
-    def test_none_bellman_period_raises(self):
-        with self.assertRaises(TypeError):
-            maliar.maliar_training_loop(
-                None,
-                self.loss_fn,
-                self.states,
-                self.calibration,
-                random_seed=TEST_SEED,
-            )
-
-    def test_non_callable_loss_raises(self):
-        with self.assertRaises(TypeError):
-            maliar.maliar_training_loop(
-                self.bp,
-                "not_a_function",
-                self.states,
-                self.calibration,
-                random_seed=TEST_SEED,
-            )
-
-    def test_none_parameters_raises(self):
-        with self.assertRaises(TypeError):
-            maliar.maliar_training_loop(
-                self.bp,
-                self.loss_fn,
-                self.states,
-                None,
-                random_seed=TEST_SEED,
-            )
+    def test_big_t_one_output_shape_matches_input(self):
+        """Output tensor shape should match input tensor shape after one step."""
+        result = maliar.simulate_forward(self.states, self.bp, self.policy, {}, big_t=1)
+        self.assertEqual(result["m"].shape, self.states["m"].shape)
+        self.assertEqual(result["g"].shape, self.states["g"].shape)
 
 
-class TestMaliarHyperparameters(unittest.TestCase):
-    """Test that network_width and epochs_per_iteration affect training."""
+class TestComputeSlack(unittest.TestCase):
+    """Test EulerEquationLoss._compute_slack."""
 
     def setUp(self):
-        torch.manual_seed(TEST_SEED)
-        np.random.seed(TEST_SEED)
-        torch.use_deterministic_algorithms(True, warn_only=True)
-        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-
-        rng = np.random.default_rng(TEST_SEED)
-        case_4["block"].construct_shocks(case_4["calibration"], rng=rng)
-
-        self.bp = case_4["bp"]
-        self.states = grid.Grid.from_config(
-            {
-                "m": {"min": 0, "max": 5, "count": 3},
-                "g": {"min": 0, "max": 5, "count": 3},
-            }
+        self.block = model.DBlock(
+            name="slack_test",
+            dynamics={
+                "m": lambda a, R: R * a,
+                "c": model.Control(
+                    iset=["m"],
+                    upper_bound=lambda m: m,
+                    agent="consumer",
+                ),
+                "a": lambda m, c: m - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
         )
-        self.loss_fn = loss.EstimatedDiscountedLifetimeRewardLoss(
-            self.bp, 2, case_4["calibration"]
-        )
-        self.calibration = case_4["calibration"]
-
-    def test_network_width_affects_parameter_count(self):
-        net_narrow, _ = maliar.maliar_training_loop(
+        self.bp = bellman.BellmanPeriod(self.block, "beta", {"beta": 0.95, "R": 1.04})
+        self.loss_fn = loss.EulerEquationLoss(
             self.bp,
-            self.loss_fn,
-            self.states,
-            self.calibration,
-            network_width=8,
-            max_iterations=1,
-            random_seed=TEST_SEED,
-        )
-        net_wide, _ = maliar.maliar_training_loop(
-            self.bp,
-            self.loss_fn,
-            self.states,
-            self.calibration,
-            network_width=32,
-            max_iterations=1,
-            random_seed=TEST_SEED,
+            parameters={"beta": 0.95, "R": 1.04},
+            constrained=True,
         )
 
-        params_narrow = sum(p.numel() for p in net_narrow.parameters())
-        params_wide = sum(p.numel() for p in net_wide.parameters())
-        self.assertGreater(
-            params_wide,
-            params_narrow,
-            "Wider network should have more parameters",
+    def test_slack_positive_when_not_binding(self):
+        """Slack > 0 when control is below upper bound."""
+        states_t = {"a": torch.tensor([2.0])}
+        shocks_t = {}
+        controls_t = {"c": torch.tensor([1.0])}  # c < m = R*a = 2.08
+        slack = self.loss_fn._compute_slack("c", controls_t, states_t, shocks_t)
+        self.assertIsNotNone(slack)
+        self.assertTrue((slack > 0).all())
+
+    def test_slack_zero_when_binding(self):
+        """Slack ≈ 0 when control equals upper bound."""
+        states_t = {"a": torch.tensor([2.0])}
+        shocks_t = {}
+        ub = 1.04 * 2.0  # m = R*a
+        controls_t = {"c": torch.tensor([ub])}
+        slack = self.loss_fn._compute_slack("c", controls_t, states_t, shocks_t)
+        self.assertIsNotNone(slack)
+        self.assertAlmostEqual(slack.item(), 0.0, places=4)
+
+    def test_no_upper_bound_returns_none(self):
+        """Control without upper_bound returns None."""
+        block_no_ub = model.DBlock(
+            name="no_ub",
+            dynamics={
+                "c": model.Control(iset=["a"]),
+                "a": lambda a, c: a - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
         )
+        bp_no_ub = bellman.BellmanPeriod(block_no_ub, "beta", {"beta": 0.95})
+        loss_fn = loss.EulerEquationLoss(bp_no_ub, parameters={"beta": 0.95})
+        slack = loss_fn._compute_slack(
+            "c", {"c": torch.tensor([1.0])}, {"a": torch.tensor([2.0])}, {}
+        )
+        self.assertIsNone(slack)
+
+
+class TestMultiControlConstrainedLoss(unittest.TestCase):
+    """Test constrained Euler loss with multi-control model (S6)."""
+
+    def test_multi_control_constrained_produces_finite_loss(self):
+        """Fischer-Burmeister works on a multi-control model with upper bounds."""
+        block = model.DBlock(
+            name="multi_ctrl_constrained",
+            dynamics={
+                "c1": model.Control(["a"], upper_bound=lambda a: a),
+                "c2": model.Control(["a"], upper_bound=lambda a: a),
+                "a": lambda a, c1, c2: a - c1 - c2,
+                "u": lambda c1, c2: torch.log(c1 + 1e-8) + torch.log(c2 + 1e-8),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+
+        loss_fn = loss.EulerEquationLoss(bp, parameters={"beta": 0.9}, constrained=True)
+
+        input_grid = grid.Grid.from_dict({"a": torch.linspace(1.0, 5.0, 5)})
+
+        def df(states, shocks, params):
+            a = states["a"]
+            return {"c1": a * 0.2, "c2": a * 0.1}
+
+        result = loss_fn(df, input_grid)
+        self.assertIsInstance(result, torch.Tensor)
+        self.assertTrue(torch.all(torch.isfinite(result)))
+        self.assertTrue(torch.all(result >= 0))
+
+
+class TestEulerEquationLossWeightValidation(unittest.TestCase):
+    """Test weight validation for EulerEquationLoss (S2)."""
+
+    def test_zero_weight_raises(self):
+        block = model.DBlock(
+            name="test",
+            dynamics={
+                "c": model.Control(["a"]),
+                "a": lambda a, c: a - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        with self.assertRaises(ValueError, msg="weight must be > 0"):
+            loss.EulerEquationLoss(bp, parameters={"beta": 0.9}, weight=0.0)
+
+    def test_negative_weight_raises(self):
+        block = model.DBlock(
+            name="test",
+            dynamics={
+                "c": model.Control(["a"]),
+                "a": lambda a, c: a - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        with self.assertRaises(ValueError, msg="weight must be > 0"):
+            loss.EulerEquationLoss(bp, parameters={"beta": 0.9}, weight=-1.0)
+
+
+class TestBellmanEquationLossValidation(unittest.TestCase):
+    """Test validation for BellmanEquationLoss (S2)."""
+
+    def test_non_callable_value_network_raises(self):
+        block = model.DBlock(
+            name="test",
+            dynamics={
+                "c": model.Control(["a"]),
+                "a": lambda a, c: a - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        with self.assertRaises(TypeError, msg="value_network must be callable"):
+            loss.BellmanEquationLoss(bp, value_network="not_callable")
+
+    def test_negative_foc_weight_raises(self):
+        block = model.DBlock(
+            name="test",
+            dynamics={
+                "c": model.Control(["a"]),
+                "a": lambda a, c: a - c,
+                "u": lambda c: torch.log(c + 1e-8),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        with self.assertRaises(ValueError, msg="foc_weight must be >= 0"):
+            loss.BellmanEquationLoss(
+                bp, value_network=lambda s, sh, p: s["a"], foc_weight=-0.5
+            )

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -180,7 +180,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
         no_control_block.construct_shocks({})
 
         # Create a dummy value network for error testing
-        def dummy_value_network(wealth):
+        def dummy_value_function(wealth):
             return 10.0 * wealth
 
         # Test with block that has no rewards
@@ -198,7 +198,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
         nrbp = bellman.BellmanPeriod(no_reward_block, "beta", {"beta": 0.95})
 
         with self.assertRaises(Exception) as context:
-            loss.BellmanEquationLoss(nrbp, dummy_value_network)
+            loss.BellmanEquationLoss(nrbp, dummy_value_function)
         self.assertIn("No reward variables found in block", str(context.exception))
 
     def test_bellman_loss_function_integration(self):
@@ -215,13 +215,13 @@ class TestBellmanLossFunctions(unittest.TestCase):
             return {"consumption": consumption}
 
         # Create a simple value network with correct interface
-        def simple_value_network(states_t, shocks_t, parameters):
+        def simple_value_function(states_t, shocks_t, parameters):
             wealth = states_t["wealth"]
             return 10.0 * wealth  # Linear value function
 
         loss_function = loss.BellmanEquationLoss(
             self.bp,
-            simple_value_network,
+            simple_value_function,
             self.parameters,
         )
 
@@ -247,7 +247,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
         """Test that independent shock realizations produce different results than identical shocks."""
 
         # Create a simple value network that depends on income
-        def simple_value_network(states_t, shocks_t, parameters):
+        def simple_value_function(states_t, shocks_t, parameters):
             wealth = states_t["wealth"]
             income = shocks_t["income"]
             return (
@@ -270,7 +270,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
 
         residual_identical = bellman.estimate_bellman_residual(
             self.bp,
-            simple_value_network,
+            simple_value_function,
             self.decision_function,
             states_t,
             shocks_identical,
@@ -279,7 +279,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
 
         residual_independent = bellman.estimate_bellman_residual(
             self.bp,
-            simple_value_network,
+            simple_value_function,
             self.decision_function,
             states_t,
             shocks_independent,
@@ -296,7 +296,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
     def test_bellman_residual_error_handling(self):
         """Test error handling in the refactored Bellman residual function."""
 
-        def simple_value_network(states_t, shocks_t, parameters):
+        def simple_value_function(states_t, shocks_t, parameters):
             wealth = states_t["wealth"]
             return 10.0 * wealth
 
@@ -311,7 +311,7 @@ class TestBellmanLossFunctions(unittest.TestCase):
         with self.assertRaises(KeyError):
             bellman.estimate_bellman_residual(
                 self.bp,
-                simple_value_network,
+                simple_value_function,
                 self.decision_function,
                 states_t,
                 shocks_missing_t1,
@@ -801,7 +801,7 @@ class TestEulerEquationLossWeightValidation(unittest.TestCase):
 class TestBellmanEquationLossValidation(unittest.TestCase):
     """Test validation for BellmanEquationLoss (S2)."""
 
-    def test_non_callable_value_network_raises(self):
+    def test_non_callable_value_function_raises(self):
         block = model.DBlock(
             name="test",
             dynamics={
@@ -812,8 +812,10 @@ class TestBellmanEquationLossValidation(unittest.TestCase):
             reward={"u": "consumer"},
         )
         bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
-        with self.assertRaises(TypeError, msg="value_network must be callable"):
-            loss.BellmanEquationLoss(bp, value_network="not_callable")
+        with self.assertRaises(
+            TypeError, msg="value_function must be a callable or a dict"
+        ):
+            loss.BellmanEquationLoss(bp, value_function="not_callable")
 
     def test_negative_foc_weight_raises(self):
         block = model.DBlock(
@@ -828,5 +830,7 @@ class TestBellmanEquationLossValidation(unittest.TestCase):
         bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
         with self.assertRaises(ValueError, msg="foc_weight must be >= 0"):
             loss.BellmanEquationLoss(
-                bp, value_network=lambda s, sh, p: s["a"], foc_weight=-0.5
+                bp,
+                value_function=lambda s, sh, p: s["a"],
+                foc_weight=-0.5,
             )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,3 +116,68 @@ class TestComputeGradientsForTensors(unittest.TestCase):
         x = torch.tensor(3.0, requires_grad=True)
         grads = compute_gradients_for_tensors({}, {"x": x})
         self.assertEqual(grads, {})
+
+
+class TestFischerBurmeister(unittest.TestCase):
+    """Test the Fischer-Burmeister complementarity function."""
+
+    def test_both_zero(self):
+        """FB(0, 0) = 0."""
+        a = torch.tensor(0.0)
+        h = torch.tensor(0.0)
+        result = utils.fischer_burmeister(a, h)
+        self.assertAlmostEqual(result.item(), 0.0, places=5)
+
+    def test_complementary_slackness(self):
+        """FB(0, s) ≈ 0 for s > 0 and FB(f, 0) ≈ 0 for f > 0."""
+        # When one is zero and the other is positive, FB should be ≈ 0
+        s = torch.tensor(2.0)
+        result = utils.fischer_burmeister(torch.tensor(0.0), s)
+        self.assertAlmostEqual(result.item(), 0.0, places=4)
+
+        f = torch.tensor(3.0)
+        result = utils.fischer_burmeister(f, torch.tensor(0.0))
+        self.assertAlmostEqual(result.item(), 0.0, places=4)
+
+    def test_violation_nonzero(self):
+        """FB(a, h) != 0 when both a > 0 and h > 0."""
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        result = utils.fischer_burmeister(a, h)
+        self.assertNotAlmostEqual(result.item(), 0.0, places=2)
+
+    def test_differentiable(self):
+        """FB is differentiable through autograd."""
+        a = torch.tensor(1.0, requires_grad=True)
+        h = torch.tensor(2.0, requires_grad=True)
+        result = utils.fischer_burmeister(a, h)
+        result.backward()
+        self.assertIsNotNone(a.grad)
+        self.assertIsNotNone(h.grad)
+        self.assertTrue(torch.isfinite(a.grad))
+        self.assertTrue(torch.isfinite(h.grad))
+
+    def test_differentiable_at_zero(self):
+        """FB gradient is finite near zero due to epsilon safeguard."""
+        a = torch.tensor(0.0, requires_grad=True)
+        h = torch.tensor(0.0, requires_grad=True)
+        result = utils.fischer_burmeister(a, h)
+        result.backward()
+        self.assertTrue(torch.isfinite(a.grad))
+        self.assertTrue(torch.isfinite(h.grad))
+
+
+class TestFischerBurmeisterEpsValidation(unittest.TestCase):
+    """Test eps parameter validation."""
+
+    def test_zero_eps_raises(self):
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        with self.assertRaises(ValueError, msg="eps must be > 0"):
+            utils.fischer_burmeister(a, h, eps=0.0)
+
+    def test_negative_eps_raises(self):
+        a = torch.tensor(1.0)
+        h = torch.tensor(1.0)
+        with self.assertRaises(ValueError, msg="eps must be > 0"):
+            utils.fischer_burmeister(a, h, eps=-1e-12)


### PR DESCRIPTION
Replaces part of #184. Stacked under #PR2 (training infrastructure).

## Summary

Refactor of `BellmanPeriod` and the Euler/Bellman residual framework. **No training-loop changes** in this PR; those land in the follow-up.

## BellmanPeriod gains

- `compute_pre_decision_state`, `resolve_discount_factor` methods
- `grad_reward_function`, `grad_transition_function`, `grad_pre_state_function` for Euler residual gradient propagation
- `_resolve_parameters`, `_resolve_decision_rules`, `_resolve_shocks` helpers
- `get_reward_syms` (multi-agent), `get_reward_sym` as single-agent shorthand
- Type hints throughout, restructured docstrings

## bellman.py module level

- `fischer_burmeister(a, h)` for smooth complementarity (KKT conditions)
- `estimate_bellman_foc_residual`: first-order condition from the Bellman equation, using autograd through the value network
- `_euler_residual_single_control` + `_chain_rule_return_factor` as building blocks for multi-control Euler residuals

## API breaks (each carried through to loss.py in this PR)

- `estimate_euler_residual` no longer takes `discount_factor`; resolved from `bellman_period.discount_variable`. Returns `dict[control_sym, Tensor]` to support multi-control models.
- `_extract_period_shocks` signature unified

## Loss-side changes (loss.py)

- `_EquationLossBase` ABC with `_extract_states_and_shocks` shared method
- `EulerEquationLoss`: drops `discount_factor` arg; gains constrained mode using Fischer-Burmeister; multi-control support; weight parameter
- `BellmanEquationLoss`: gains `foc_weight` parameter for the weighted FOC term (MMW eq. 14)
- Loss inputs centralized via `_prepare_loss_inputs` helper

## Tests

286/286 pass on this branch alone. Integration tests that need both framework and training (e.g., `TestEulerResidualsBenchmarks`, `TestU3ConstrainedRegionBehavior`, `TestMaliarTrainingLoop`) are deferred to the follow-up PR with their training-side dependencies.