### PR TITLE
Documentation correctness pass: runnable snippets, API coverage, build hygiene

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,5 @@ build:
     - asdf global uv latest
     - uv venv
     - uv pip install .[docs]
-    - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D
-      language=en docs $READTHEDOCS_OUTPUT/html
+    - .venv/bin/python -m sphinx -T -W --keep-going -b html -d
+      docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,41 @@ and this project adheres to
   `2.0`.
 - `train_block_nn` now halts early with a warning on a non-finite (NaN/Inf) loss
   instead of continuing to train on poisoned weights.
+- Documentation correctness pass across `docs/` and the examples gallery: the
+  `index.md` and quickstart simulation snippets ran `simulate()` without
+  `initialize_sim()` and paired `consumption_block` with an initial state it
+  does not carry (both crashed verbatim; they now simulate `cons_problem` and
+  were verified by execution); the quickstart built `BlockPolicyNet` from a raw
+  `DBlock` and read a nonexistent `hidden1` attribute; the parser API example
+  used `gamma`, which SymPy parses as the gamma function; `blocks.md` live
+  sections referenced a `portfolio_block` defined only inside a comment; the
+  benchmark docs said six registry entries instead of seven (D-4 was
+  undocumented); gallery narratives contradicted the actual calibrations
+  (resource-extraction parameters, the U-2 policy's human-wealth intercept, the
+  D-3 median lifetime, and the U-1 smoothing factor).
+- New API reference pages for `skagent.bellman`, `skagent.loss`,
+  `skagent.distributions`, `skagent.model_analyzer`/`model_visualizer`, and
+  `skagent.rule`; added missing entries for `BlockValueNet`,
+  `BlockPolicyValueNet`, `train_block_nn`, and `get_reference_policy`; the
+  simulation API page no longer documents `MonteCarloSimulator` as a class
+  distinct from `Simulator` (it is an alias).
+- `solve_multiple_controls` default-loss path crashed (`AttributeError` on
+  `None`) and called the loss constructor with a stray positional argument; it
+  now resolves `skagent.loss.StaticRewardLoss` and matches its signature. The
+  function still has no tests or callers.
+- Importing `skagent.simulation.monte_carlo` or `skagent.models.benchmarks` on
+  Python 3.9 raised `TypeError` from PEP 604 unions evaluated without
+  `from __future__ import annotations`; the imports were added. The `Simulator`
+  block parameter is annotated `Union[DBlock, RBlock]` to match documented
+  usage.
+- Docs build hygiene: `plot_gallery` is a bool; the unused
+  `autosummary_generate` flag is gone; the copyright year derives from the build
+  date; `sphinx-autobuild` joins the `docs` extra so `make livehtml` works; Read
+  the Docs builds with `-W --keep-going` like CI; the empty
+  `examples/simulation/` gallery section was removed.
+- Project metadata: the PyPI description placeholder ("A great package.") was
+  replaced and the Development Status classifier bumped from Planning to
+  Pre-Alpha, matching the roadmap's v0.1 proof-of-concept status.
 
 ...
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 **scikit-agent** is a scientific Python toolkit for agent-based economic
 modeling and multi-agent systems design. It provides a unified interface for
 creating, solving, and simulating economic models using modern computational
-methods including deep reinforcement learning as well as more traditional
-numerical techniques.
+methods including deep learning as well as more traditional numerical
+techniques.
 
 Our goal is for `scikit-agent` to be for computational social scientific
 modeling and statistics what `scikit-learn` is for machine learning.
@@ -26,7 +26,7 @@ modeling and statistics what `scikit-learn` is for machine learning.
   ecosystem
 - **Modular modeling system**. Construct multi-agent environments from modular
   blocks of structural equations.
-- **Solution algorithms** including deep reinforcement learning methods.
+- **Solution algorithms** including deep learning methods.
 - **Simulation tools** for generating synthetic data and running policy
   experiments
 

--- a/docs/DOCS_DEPLOYMENT.md
+++ b/docs/DOCS_DEPLOYMENT.md
@@ -106,12 +106,12 @@ git push origin main
 
 ```bash
 # Build docs locally
-pip install ".[docs]"
+uv pip install ".[docs]"
 cd docs
-python -m sphinx -b html . _build
+uv run python -m sphinx -b html . _build
 
 # Serve locally
-python -m http.server 8000 -d _build
+uv run python -m http.server 8000 -d _build
 ```
 
 ## 🐛 Troubleshooting

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ BUILDDIR     = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help clean html livehtml Makefile
 
 # Catch-all target: route all unknown targets to Sphinx-Gallery using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/api/algorithms.md
+++ b/docs/api/algorithms.md
@@ -1,12 +1,13 @@
 # Algorithms
 
-This section contains the API documentation for solution algorithms and
-optimization methods used to solve economic models.
+This section contains the API documentation for solution algorithms, neural
+network components, and grid tools used to solve dynamic stochastic optimization
+problems.
 
-## Value Function Iteration
+## Value Backwards Induction (VBI)
 
-The Value Function Iteration (VBI) algorithm implements backwards induction to
-derive value functions from model blocks.
+The value backwards induction (VBI) algorithm derives arrival value functions
+from a continuation value function and the stage dynamics of model blocks.
 
 ```{eval-rst}
 .. automodule:: skagent.algos.vbi
@@ -59,7 +60,7 @@ Base neural network class with device management.
 
 ### BlockPolicyNet
 
-Specialized neural network for policy functions in economic models.
+A neural network for policy functions in dynamic programming problems.
 
 ```{eval-rst}
 .. autoclass:: skagent.ann.BlockPolicyNet
@@ -68,7 +69,34 @@ Specialized neural network for policy functions in economic models.
    :show-inheritance:
 ```
 
+### BlockValueNet
+
+A neural network for value functions in dynamic programming problems.
+
+```{eval-rst}
+.. autoclass:: skagent.ann.BlockValueNet
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### BlockPolicyValueNet
+
+A shared-backbone neural network that jointly represents the policy and value
+functions.
+
+```{eval-rst}
+.. autoclass:: skagent.ann.BlockPolicyValueNet
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
 ### Training Functions
+
+```{eval-rst}
+.. autofunction:: skagent.ann.train_block_nn
+```
 
 ```{eval-rst}
 .. autofunction:: skagent.ann.aggregate_net_loss
@@ -94,7 +122,3 @@ Specialized neural network for policy functions in economic models.
 ```{eval-rst}
 .. autofunction:: skagent.grid.cartesian_product
 ```
-
----
-
-_This page is under construction. Content will be added as the API develops._

--- a/docs/api/analysis.md
+++ b/docs/api/analysis.md
@@ -1,0 +1,18 @@
+# Model Analysis and Visualization
+
+These modules extract structured metadata from block models and render it as
+plate-notation diagrams.
+
+## Model Analyzer
+
+```{eval-rst}
+.. automodule:: skagent.model_analyzer
+   :members:
+```
+
+## Model Visualizer
+
+```{eval-rst}
+.. automodule:: skagent.model_visualizer
+   :members:
+```

--- a/docs/api/bellman.md
+++ b/docs/api/bellman.md
@@ -1,0 +1,12 @@
+# Bellman Periods
+
+The bellman module turns block models into dynamic stochastic optimization
+problems (DSOPs). Its module docstring below defines the meta-model notation
+(arrival states, shocks, pre-decision states, controls, and rewards within a
+period) used throughout the library, and `BellmanPeriod` is the central object
+consumed by the neural network components and loss functions.
+
+```{eval-rst}
+.. automodule:: skagent.bellman
+   :members:
+```

--- a/docs/api/distributions.md
+++ b/docs/api/distributions.md
@@ -1,0 +1,17 @@
+# Distributions
+
+The distributions module provides probability distributions used for shocks and
+initial conditions. Continuous distributions support both drawing random samples
+and discretization into point-mass approximations.
+
+```{note}
+`Normal` and `Lognormal` are parameterized by the distribution's mean and
+standard deviation in levels, not by the log-space parameters
+$(\mu, \sigma)$ familiar from other libraries. A standard deviation of zero
+produces a degenerate point mass at the `mean` argument.
+```
+
+```{eval-rst}
+.. automodule:: skagent.distributions
+   :members:
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,10 +6,14 @@ This section contains the complete API documentation for scikit-agent.
 :maxdepth: 2
 
 blocks
+bellman
 models
 algorithms
+loss
+distributions
 simulation
 parser
+analysis
 utils
 ```
 
@@ -18,10 +22,14 @@ utils
 The scikit-agent API is organized into several main modules:
 
 - {doc}`blocks` - Building blocks -- modular model components
+- {doc}`bellman` - Bellman periods and the meta-model notation
 - {doc}`models` - Canonical models from scientific literature
 - {doc}`algorithms` - Solution algorithms and optimization methods
+- {doc}`loss` - Loss functions for neural network training
+- {doc}`distributions` - Distributions for shocks and initial conditions
 - {doc}`simulation` - Simulation tools and analysis functions
 - {doc}`parser` - Parsing strings into mathematical expressions
+- {doc}`analysis` - Model analysis and visualization
 - {doc}`utils` - Utility functions and helpers
 
 ## Quick Reference

--- a/docs/api/loss.md
+++ b/docs/api/loss.md
@@ -1,0 +1,11 @@
+# Loss Functions
+
+The loss module provides the objective functions minimized during neural network
+training. Each loss wraps a `BellmanPeriod` and encodes a different optimality
+criterion: static reward maximization, estimated discounted lifetime reward,
+Bellman equation residuals, or Euler equation residuals.
+
+```{eval-rst}
+.. automodule:: skagent.loss
+   :members:
+```

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -32,6 +32,7 @@ below.
 .. autofunction:: skagent.models.benchmarks.get_benchmark_calibration
 .. autofunction:: skagent.models.benchmarks.get_analytical_policy
 .. autofunction:: skagent.models.benchmarks.has_analytical_policy
+.. autofunction:: skagent.models.benchmarks.get_reference_policy
 .. autofunction:: skagent.models.benchmarks.get_test_states
 .. autofunction:: skagent.models.benchmarks.get_custom_validation
 ```

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -33,18 +33,38 @@ callable functions.
    :no-index:
 ```
 
+## Rules
+
+The rule module builds on the parser to extract dependencies and formulas from
+model rules.
+
+```{eval-rst}
+.. automodule:: skagent.rule
+   :members:
+```
+
 ## Example Usage
 
 ### Parsing Mathematical Expressions
 
 ```python
+import inspect
+
 from skagent.parser import math_text_to_lambda
 
-# Convert string expression to callable function
-utility_func = math_text_to_lambda("c**(1-gamma)/(1-gamma)")
+# Convert a string expression to a callable function
+reward_func = math_text_to_lambda("c**(1-rho)/(1-rho)")
 
-# Use the function
-gamma = 2.0
-c = 1.5
-utility = utility_func(c, gamma)
+# The positional argument order follows the expression's free symbols.
+# Check it before calling the function positionally:
+inspect.signature(reward_func)  # (c, rho)
+
+reward = reward_func(1.5, 2.0)
+```
+
+```{warning}
+Variable names that collide with built-in SymPy objects are parsed as those
+objects rather than as free variables. For example, `gamma` is parsed as the
+gamma *function*, so `math_text_to_lambda("c**(1-gamma)/(1-gamma)")` raises a
+`TypeError`. Prefer names like `rho` or `CRRA` for curvature parameters.
 ```

--- a/docs/api/simulation.md
+++ b/docs/api/simulation.md
@@ -5,28 +5,26 @@ functions.
 
 ## Monte Carlo Simulation
 
-The simulation module provides Monte Carlo simulation engines for economic
+The simulation module provides Monte Carlo simulation engines for block-based
 models.
 
-### MonteCarloSimulator
+### Simulator
 
-A simplified Monte Carlo simulation engine that doesn't make assumptions about
-aging or mortality.
-
-```{eval-rst}
-.. autoclass:: skagent.simulation.monte_carlo.MonteCarloSimulator
-   :members:
-   :undoc-members:
-   :show-inheritance:
-```
-
-### Base Simulator
+The base Monte Carlo simulation engine. It makes no assumptions about aging or
+mortality; demographic features are expressed declaratively as blocks (see the
+mortality example below).
 
 ```{eval-rst}
 .. autoclass:: skagent.simulation.monte_carlo.Simulator
    :members:
    :undoc-members:
    :show-inheritance:
+```
+
+```{note}
+`MonteCarloSimulator` is an alias for `Simulator`, kept for backward
+compatibility. The examples below use the alias because it is what
+`skagent.__init__` exports.
 ```
 
 ## Simulation Utility Functions
@@ -79,7 +77,10 @@ simulator = ska.MonteCarloSimulator(
     calibration=calibration,
     block=mortal_cons_problem,
     dr={"c": lambda m: m / 3},
-    initial={"k": Lognormal(-6, 0), "p": 1.0, "age": 0},
+    # Initial states may be scalars or distributions. Lognormal takes the
+    # distribution's mean and standard deviation in levels; newborns draw
+    # their starting capital from it.
+    initial={"k": Lognormal(1.0, 0.5), "p": 1.0, "age": 0},
     agent_count=1000,
     T_sim=50,
 )
@@ -87,7 +88,3 @@ simulator = ska.MonteCarloSimulator(
 simulator.initialize_sim()
 results = simulator.simulate()
 ```
-
----
-
-_This page is under construction. Content will be added as the API develops._

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -13,28 +13,40 @@ The utils module contains general-purpose utility functions.
 
 ## Example Usage
 
-### Working with Grids
+### Calling a Function from a Dictionary of Values
+
+`apply_fun_to_vals` calls a function using only the entries of a dictionary that
+match the function's named arguments, ignoring the rest:
 
 ```python
-import skagent as ska
+from skagent.utils import apply_fun_to_vals
 
-# Create a grid configuration
-config = {
-    "wealth": {"min": 0.0, "max": 10.0, "count": 50},
-    "income": {"min": 0.5, "max": 2.0, "count": 20},
-}
 
-# Create grid
-grid = ska.Grid.from_config(config)
+def transition(a, b):
+    return a + b
 
-# Access grid points
-wealth_points = grid["wealth"]
-income_points = grid["income"]
 
-# Convert to dictionary
-grid_dict = grid.to_dict()
+# The extra key "c" is ignored
+apply_fun_to_vals(transition, {"a": 1.0, "b": 2.0, "c": 99.0})  # 3.0
 ```
 
----
+### Smooth Complementarity Conditions
 
-_This page is under construction. Content will be added as the API develops._
+`fischer_burmeister` replaces the complementarity conditions
+$a \geq 0,\; h \geq 0,\; ah = 0$ with a single smooth equation, which is useful
+for occasionally binding constraints in loss functions:
+
+```python
+import torch
+
+from skagent.utils import fischer_burmeister
+
+a = torch.tensor([0.0, 1.0, 3.0])
+h = torch.tensor([2.0, 0.0, 4.0])
+fischer_burmeister(a, h)  # tensor([0., 0., 2.])
+```
+
+```{note}
+Grid construction tools (`Grid`, `make_grid`, `cartesian_product`) live in
+`skagent.grid` and are documented on the {doc}`algorithms` page.
+```

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -24,7 +24,7 @@ environments and plan to do so in future releases.
   enable agents to interact both interpersonally and through aggregate
   structures, such as markets.
 - **Multiple agent roles**. We will support models with agents varying widely in
-  roles, including different reward and action spaces.
+  roles, including different reward and control spaces.
 - **Strategic equilibrium solvers**. Efficiently solving for strategic
   equilibrium between multiple agents.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import datetime
 import importlib.metadata
 from typing import Any
 
 project = "scikit-agent"
-copyright = "2025, scikit-agent Team"
+copyright = f"{datetime.date.today().year}, scikit-agent Team"
 author = "scikit-agent Team"
 version = release = importlib.metadata.version("scikit_agent")
 
@@ -25,7 +26,7 @@ sphinx_gallery_conf = {
     "gallery_dirs": "auto_examples",  # path to gallery generated output
     "filename_pattern": "/plot_",  # pattern to match example files
     "ignore_pattern": r"__init__\.py",  # patterns to ignore
-    "plot_gallery": "True",  # create a gallery
+    "plot_gallery": True,  # create a gallery
     "download_all_examples": False,  # don't create zip downloads by default
     "remove_config_comments": True,  # remove config comments from examples
     "expected_failing_examples": [],  # list of examples expected to fail
@@ -101,7 +102,6 @@ html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
 # Auto-generated API docs
-autosummary_generate = True
 autodoc_typehints = "description"
 autodoc_typehints_description_target = "documented"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,13 @@ community/index
 
 ```python
 import skagent as ska
-from skagent.models.consumer import consumption_block, calibration
+from skagent.models.consumer import cons_problem, calibration
 
-# Create a consumption-saving model
-model = consumption_block
-model.construct_shocks(calibration)
+# A consumption-saving model: a consumption block chained with a
+# tick block that carries end-of-period assets into next period's
+# capital. The simulator constructs the shock distributions from
+# the calibration internally.
+model = cons_problem
 
 # Define simple decision rule
 decision_rules = {"c": lambda m: 0.9 * m}
@@ -32,11 +34,12 @@ simulator = ska.MonteCarloSimulator(
     calibration=calibration,
     block=model,
     dr=decision_rules,
-    initial={"k": 1.0, "p": 1.0},
+    initial={"k": 1.0},
     agent_count=1000,
     T_sim=50,
 )
 
+simulator.initialize_sim()
 results = simulator.simulate()
 ```
 
@@ -63,7 +66,7 @@ Learn to build custom models using DBlocks and economic building blocks
 :link: user_guide/algorithms
 :link-type: doc
 
-Explore solution methods from VFI to neural networks
+Explore solution methods from value backwards induction to neural networks
 :::
 
 :::{grid-item-card} 📈 Simulation Guide

--- a/docs/user_guide/algorithms.md
+++ b/docs/user_guide/algorithms.md
@@ -7,9 +7,11 @@ scikit-agent.
 
 Learn about different approaches to solving economic models:
 
-- **All-in-One Deep Learning Methods** : Deep learning solvers that use an
-  All-in-One (AiO) objective function
-- **Value Function Iteration**: Classical dynamic programming approaches
+- **Maliar-style deep learning methods**: Neural network solvers following
+  Maliar, Maliar, and Winant (2021), which train on an all-in-one (AiO)
+  objective function
+- **Value backwards induction (VBI)**: Classical dynamic programming via
+  backwards induction on a grid
 
 ## Algorithm Configuration
 

--- a/docs/user_guide/benchmark_models.md
+++ b/docs/user_guide/benchmark_models.md
@@ -28,7 +28,7 @@ registry contains and how to call it.
 
 ## Roster
 
-The models below split into two groups. Six ship in the `BENCHMARK_MODELS`
+The models below split into two groups. Seven ship in the `BENCHMARK_MODELS`
 registry, each reachable through
 {py:func}`~skagent.models.benchmarks.list_benchmark_models` by the short
 registry key shown in the table. Those keys, such as `D-1` or `U-2`, are
@@ -39,14 +39,19 @@ as standalone modules.
 **Registry models** (fetch with
 {py:func}`~skagent.models.benchmarks.get_benchmark_model` and the registry key):
 
-| Model                                          | Key   | Utility   | Income                    | Closed form            |
-| ---------------------------------------------- | ----- | --------- | ------------------------- | ---------------------- |
-| Finite-horizon log utility                     | `D-1` | Log       | Wealth only               | Remaining-horizon MPC  |
-| Infinite-horizon perfect foresight             | `D-2` | CRRA      | Constant $y$              | Linear in total wealth |
-| Blanchard mortality                            | `D-3` | CRRA      | Constant $y$              | Same with $s\beta$     |
-| Hall random walk                               | `U-1` | Quadratic | Stochastic, $\beta R = 1$ | PIH annuity rule       |
-| Log utility with permanent shocks (normalized) | `U-2` | Log       | Geometric random walk     | $c = (1-\beta)(m + h)$ |
-| Buffer stock                                   | `U-3` | CRRA      | Geometric random walk     | None (numerical only)  |
+| Model                                          | Key   | Utility   | Income                           | Closed form                 |
+| ---------------------------------------------- | ----- | --------- | -------------------------------- | --------------------------- |
+| Finite-horizon log utility                     | `D-1` | Log       | Wealth only                      | Remaining-horizon MPC       |
+| Infinite-horizon perfect foresight             | `D-2` | CRRA      | Constant $y$                     | Linear in total wealth      |
+| Blanchard mortality                            | `D-3` | CRRA      | Constant $y$                     | Same with $s\beta$          |
+| Hall random walk                               | `U-1` | Quadratic | Stochastic[^br]                  | PIH annuity rule            |
+| Log utility with permanent shocks (normalized) | `U-2` | Log       | Geometric random walk            | $c = (1-\beta)(m + h)$      |
+| Buffer stock                                   | `U-3` | CRRA      | Geometric random walk            | None (numerical only)       |
+| Constrained perfect foresight                  | `D-4` | CRRA      | Constant $y$, binding constraint | None (VFI reference policy) |
+
+[^br]:
+    The U-1 closed form requires the calibration restriction $\beta R = 1$; the
+    Hall martingale result holds for any income process given that restriction.
 
 **Standalone modules (not in `BENCHMARK_MODELS`):**
 
@@ -75,7 +80,7 @@ from skagent.models.benchmarks import (
 
 list_benchmark_models()
 # {'D-1': '...', 'D-2': '...', 'D-3': '...',
-#  'U-1': '...', 'U-2': '...', 'U-3': '...'}
+#  'U-1': '...', 'U-2': '...', 'U-3': '...', 'D-4': '...'}
 
 block = get_benchmark_model("D-2")
 calibration = get_benchmark_calibration("D-2")
@@ -90,7 +95,9 @@ result["validation"]  # 'PASSED'
 
 Models without a closed form report `False` from
 {py:func}`~skagent.models.benchmarks.has_analytical_policy`, and requesting
-their analytical policy raises {py:exc}`ValueError`. For those, solve
+their analytical policy raises {py:exc}`ValueError`. The constrained `D-4` model
+instead provides a value-function-iteration reference policy through
+{py:func}`~skagent.models.benchmarks.get_reference_policy`. For the rest, solve
 numerically with {py:class}`~skagent.loss.EulerEquationLoss` and
 {py:func}`~skagent.algos.maliar.maliar_training_loop`; see {doc}`algorithms`.
 

--- a/docs/user_guide/blocks.md
+++ b/docs/user_guide/blocks.md
@@ -15,15 +15,17 @@ blocks:
   agents act
 - **RBlock (Recursive Block)**: Combines multiple blocks into a more complex
   block
-- **Bellman Block**: A period of a dynamic model
+- **BellmanPeriod**: Wraps a block (it is not itself a `Block`) together with a
+  discount variable and calibration, turning it into one period of a dynamic
+  program
 
 These blocks all define the ways that _variables_ change. The relationships
 between variables are defined in terms of _structural equations_, which in
 scikit-agent are represented as functions.
 
 Some variables are reserved as **control** variables, which are assigned to
-particular agent roles. Agents can choose a decision rule to decide their action
-at each of their control variables.
+particular agent roles. Agents choose a decision rule that determines the value
+of each of their control variables.
 
 Some variables are reserved as **reward** variables, which provide the agent
 _utility_ or incentive.
@@ -70,17 +72,19 @@ consumption_block = ska.DBlock(
 )
 ```
 
-This corresponds to the following mathematical model:
-
-<!--- correct? --->
+This corresponds to the following mathematical model, where the income shock
+$\theta$ is a mean-one lognormal with log-space standard deviation
+$\sigma = 0.1$:
 
 $$
-    \theta &\sim LogNormal(1, 0.1) \\
+\begin{aligned}
+    \log \theta &\sim \mathcal{N}(-\sigma^2 / 2,\ \sigma^2) \\
     y &= p \theta \\
     m &= b_{-1} + y \\
     c &= c(m) \\
     a &= m - c \\
-    u &= log(c) \\
+    u &= \log(c)
+\end{aligned}
 $$
 
 Here, the agent can choose its level of consumption $c$ given an _information
@@ -126,20 +130,27 @@ consumption_control = ska.Control(
 
 #### Calibration
 
+Shock parameters can be given as strings naming calibration parameters rather
+than as literal values. Calling `construct_shocks` with a calibration dictionary
+then builds the actual distributions:
+
 ```python
+income_block = ska.DBlock(
+    name="income",
+    shocks={"theta": (MeanOneLogNormal, {"sigma": "TranShkStd"})},
+    dynamics={"y": lambda p, theta: p * theta},
+)
+
 calibration = {
     "CRRA": 2.0,  # Risk aversion
     "DiscFac": 0.96,  # Discount factor
     "Rfree": 1.03,  # Risk-free rate
-    "EqP": 0.06,  # Equity premium
-    "RiskyStd": 0.20,  # Stock volatility
     "PermGroFac": 1.01,  # Permanent income growth
     "TranShkStd": 0.1,  # Transitory shock std
-    "PermShkStd": 0.05,  # Permanent shock std
 }
 
 # Apply calibration to construct actual distributions
-portfolio_block.construct_shocks(calibration)
+income_block.construct_shocks(calibration)
 ```
 
 #### String-Based Dynamics
@@ -171,15 +182,28 @@ retirement_block = ska.DBlock(
 
 # Life-cycle model
 lifecycle_model = ska.RBlock(
-    name="lifecycle_model", blocks=[portfolio_block, retirement_block]
+    name="lifecycle_model", blocks=[consumption_block, retirement_block]
 )
 ```
 
 _TODO: Discussion of how the blocks connect -- arrival states, again._
 
-### Bellman Blocks
+### Bellman Periods
 
-_TODO: about bellman blocks -- how these become MDPs_
+A `BellmanPeriod` (from `skagent.bellman`) wraps a block together with its
+discount variable and calibration, turning the block into one period of a
+dynamic stochastic optimization problem. The wrapped period exposes the reward,
+transition, and gradient functions that the neural network solution methods and
+loss functions consume:
+
+```python
+from skagent.bellman import BellmanPeriod
+
+bp = BellmanPeriod(consumption_block, "DiscFac", calibration)
+```
+
+See the {doc}`../api/bellman` reference for the period timing notation (arrival
+states, shocks, pre-decision states, controls, and rewards) and the full API.
 
 <!---
 ## Building Custom Models
@@ -314,35 +338,37 @@ aggregate_shock_block = ska.DBlock(
 
 ```python
 # Get all variables in the model
-variables = portfolio_block.get_vars()
+variables = consumption_block.get_vars()
 print("Model variables:", variables)
 
 # Get control variables
-controls = portfolio_block.get_controls()
-print("Control variables:", controls)
+controls = consumption_block.get_controls()
+print("Control variables:", list(controls.keys()))
 
 # Get shock variables
-shocks = portfolio_block.get_shocks()
+shocks = consumption_block.get_shocks()
 print("Shock variables:", list(shocks.keys()))
 ```
 
 ### Testing Model Dynamics
 
+The `transition` method advances the block by one period from a dictionary of
+arrival states and realized shock values:
+
 ```python
-# Test model transition with simple decision rules
+# Arrival states and a realized shock value
 pre_state = {
-    "m": 2.0,
+    "b": 1.0,
     "p": 1.0,
-    "a_prev": 1.0,
+    "theta": 1.0,
 }
 
 decision_rules = {
     "c": lambda m: 0.8 * m,
-    "alpha": lambda a: 0.6,  # 60% in risky asset
 }
 
 # Simulate one period
-post_state = portfolio_block.transition(pre_state, decision_rules)
+post_state = consumption_block.transition(pre_state, decision_rules)
 print("Post-transition state:", post_state)
 ```
 
@@ -393,6 +419,11 @@ def make_consumption_block(calibration=None):
 
 ## Common Patterns
 
+Recall that a variable referenced before it is assigned within a block is an
+arrival state: in the habit block below, the `h` appearing in the information
+set of `c` and in `x` is last period's habit stock, while the final equation
+assigns this period's value.
+
 ### Habit Formation Models
 
 ```python
@@ -401,7 +432,7 @@ habit_block = ska.DBlock(
         "c": ska.Control(["m", "h"]),
         "x": lambda c, h: c / h,  # Consumption relative to habit
         "u": lambda x, CRRA: x ** (1 - CRRA) / (1 - CRRA),
-        "h": lambda h_prev, c_prev, rho: rho * h_prev + (1 - rho) * c_prev,
+        "h": lambda h, c, rho: rho * h + (1 - rho) * c,  # Habit stock update
     }
 )
 ```
@@ -413,9 +444,10 @@ durables_block = ska.DBlock(
     dynamics={
         "c_nd": ska.Control(["m"]),  # Non-durable consumption
         "i_d": ska.Control(["m", "d"]),  # Durable investment
-        "d": lambda d_prev, i_d, delta: (1 - delta) * d_prev + i_d,  # Durable stock
+        "d": lambda d, i_d, delta: (1 - delta) * d + i_d,  # Durable stock
         "c_d": lambda d: d,  # Durable services
-        "u": lambda c_nd, c_d, alpha: (c_nd**alpha * c_d ** (1 - alpha)) ** (1 - CRRA)
+        "u": lambda c_nd, c_d, alpha, CRRA: (c_nd**alpha * c_d ** (1 - alpha))
+        ** (1 - CRRA)
         / (1 - CRRA),
     }
 )

--- a/docs/user_guide/installation.md
+++ b/docs/user_guide/installation.md
@@ -2,27 +2,37 @@
 
 ## Requirements
 
-scikit-agent requires:
+scikit-agent requires Python 3.9 or higher. Its main runtime dependencies are:
 
-- Python 3.9 or higher
-- NumPy
-- SciPy
-- Matplotlib
+- NumPy, SciPy, SymPy, Numba, and xarray
 - PyTorch
-- Cairo
+- Matplotlib
+- cairosvg, pydot, PyYAML, and IPython (model visualization)
 
-### macOS
+See `pyproject.toml` for the authoritative dependency list; `pip` installs all
+of these automatically.
 
-To install system dependencies:
+### System Dependencies
+
+The `cairosvg` and `pydot` packages link against the Cairo and Graphviz system
+libraries, which must be installed separately for model visualization.
+
+On macOS:
 
 ```bash
-brew install cairo libffi
+brew install cairo libffi graphviz
 ```
 
 And link Cairo by setting the environment variable:
 
 ```
 DYLD_LIBRARY_PATH=/opt/homebrew/lib:$DYLD_LIBRARY_PATH
+```
+
+On Debian/Ubuntu Linux:
+
+```bash
+sudo apt-get install libcairo2 graphviz
 ```
 
 ## Install from PyPI

--- a/docs/user_guide/quickstart.md
+++ b/docs/user_guide/quickstart.md
@@ -50,7 +50,7 @@ Let's create a simple consumption-saving model step by step.
 ```python
 import numpy as np
 import skagent as ska
-from skagent.models.consumer import consumption_block, calibration
+from skagent.models.consumer import consumption_block, cons_problem, calibration
 ```
 
 ### Step 2: Examine the Pre-built Model
@@ -85,12 +85,21 @@ for param, value in my_calibration.items():
     print(f"  {param}: {value}")
 ```
 
-### Step 4: Construct Shocks
+### Step 4: Assemble the Recursive Problem
+
+A single `DBlock` describes one period of behavior. To simulate over time, the
+end-of-period assets `a` must become next period's capital `k`. The prebuilt
+`cons_problem` is an `RBlock` that chains a normalized consumption block with a
+small "tick" block doing exactly that:
 
 ```python
-# Build the shock distributions using calibration
-consumption_block.construct_shocks(my_calibration)
+print("Recursive problem blocks:")
+for block in cons_problem.blocks:
+    print(f"  {block.name}: {list(block.get_dynamics().keys())}")
 ```
+
+There is no need to construct the shock distributions by hand; the simulator
+builds them from the calibration internally.
 
 ### Step 5: Create a Simple Decision Rule
 
@@ -113,13 +122,12 @@ decision_rules = {"c": simple_consumption_rule}
 # Set up initial conditions
 initial_conditions = {
     "k": 1.0,  # Initial capital
-    "p": 1.0,  # Initial permanent income
 }
 
 # Create simulator
 simulator = ska.MonteCarloSimulator(
     calibration=my_calibration,
-    block=consumption_block,
+    block=cons_problem,
     dr=decision_rules,
     initial=initial_conditions,
     agent_count=1000,
@@ -129,6 +137,7 @@ simulator = ska.MonteCarloSimulator(
 
 # Run simulation
 print("Running simulation...")
+simulator.initialize_sim()
 results = simulator.simulate()
 
 print(f"Simulation completed. History keys: {list(results.keys())}")
@@ -139,9 +148,10 @@ print(f"Simulation completed. History keys: {list(results.keys())}")
 ```python
 import matplotlib.pyplot as plt
 
-# Plot average consumption over time
+# Plot average consumption over time. The history values are numpy
+# arrays of shape (T_sim, agent_count).
 if "c" in simulator.history:
-    consumption_data = np.array(simulator.history["c"])
+    consumption_data = simulator.history["c"]
     mean_consumption = np.mean(consumption_data, axis=1)
 
     plt.figure(figsize=(10, 6))
@@ -168,13 +178,18 @@ print(f"First few wealth points: {wealth_grid['m'][:5]}")
 
 ## Neural Network Solutions
 
-scikit-agent supports neural network-based solution methods:
+scikit-agent supports neural network-based solution methods. Policy networks are
+built on a `BellmanPeriod`, which wraps a block together with its discount
+variable and calibration:
 
 ```python
-# Create a neural network policy
-policy_net = ska.BlockPolicyNet(consumption_block, width=64)
+from skagent.bellman import BellmanPeriod
 
-print(f"Neural network input size: {policy_net.hidden1.in_features}")
+# Wrap the block as a Bellman period, then create a policy network
+bp = BellmanPeriod(consumption_block, "DiscFac", my_calibration)
+policy_net = ska.BlockPolicyNet(bp, width=64)
+
+print(f"Neural network input size: {policy_net.layers[0].in_features}")
 print(f"Neural network output size: {policy_net.output.out_features}")
 ```
 
@@ -201,7 +216,3 @@ After completing this quickstart:
 - The package follows scikit-learn conventions for a familiar API
 
 You're now ready to build more sophisticated economic models with scikit-agent!
-
----
-
-_This page is under construction. More detailed examples will be added._

--- a/docs/user_guide/science.md
+++ b/docs/user_guide/science.md
@@ -19,7 +19,7 @@ This work was funded in part by:
 
 - National Science Foundation
   [#2131532](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2131532)
-- National Science Foudnation
+- National Science Foundation
   [#2131533](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2131533)
 - Future of Life Foundation
 

--- a/docs/user_guide/simulation.md
+++ b/docs/user_guide/simulation.md
@@ -19,8 +19,8 @@ The simulator takes the following elements in configuration:
 
 - **Calibration dictionary**. A dictionary specifying values for any free
   parameters of the model.
-- **Model**. A `Block` model, defining states, shocks, control, and reward
-  variables of an agent (or population of agents).
+- **Model**. A block model (`DBlock` or `RBlock`), defining states, shocks,
+  control, and reward variables of an agent (or population of agents).
 - **Decision rules**. A dictionary of decision rules governing the informed
   choices of agents at their decision variables.
 - **Initial values**. A dictionary of starting values, or starting
@@ -34,13 +34,13 @@ import skagent.models.consumer as cons
 from skagent.simulation.monte_carlo import MonteCarloSimulator
 
 simulator = MonteCarloSimulator(
-    cons.calibration,
-    cons.cons_problem,
-    {  # decision rules passed in as dictionary
+    calibration=cons.calibration,
+    block=cons.cons_problem,
+    dr={  # decision rules passed in as dictionary
         "c": lambda m: 0.5 * m,
     },
-    {  # distributions of starting values
-        "k": Lognormal(-6, 0),
+    initial={  # distributions of starting values, in levels
+        "k": Lognormal(1.0, 0.5),
     },
     agent_count=5,
     T_sim=10,

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -7,4 +7,6 @@ and classes in practical scenarios.
 
 Each example is designed to be self-contained and can be run independently.
 The examples demonstrate real-world usage patterns and best practices for
-using scikit-agent in your research and applications.
+using scikit-agent in your research and applications. Monte Carlo simulation
+is demonstrated within the model examples (the consumption-portfolio and
+resource extraction walkthroughs both simulate their models).

--- a/examples/algorithms/README.rst
+++ b/examples/algorithms/README.rst
@@ -5,5 +5,6 @@ This section contains examples of different algorithms available in scikit-agent
 These examples demonstrate how to use various solution methods, optimization
 algorithms, and numerical techniques.
 
-Examples include value function iteration, policy iteration, neural network
-training, and other computational approaches to solving economic models.
+The current examples cover neural network training methods following Maliar,
+Maliar, and Winant (2021). They train networks for several minutes each when
+the gallery is built from scratch.

--- a/examples/algorithms/plot_maliar_training_loop.py
+++ b/examples/algorithms/plot_maliar_training_loop.py
@@ -150,7 +150,9 @@ c = decision_fn({"a": test_a}, mean_shocks, u3_calibration)["c"].detach()
 R = u3_calibration["R"]
 m = R * test_a / mean_shocks["psi"] + mean_shocks["theta"]
 
-# Property 1: the borrowing constraint 0 < c <= m holds everywhere.
+# Property 1: the borrowing constraint 0 < c <= m holds everywhere, up to
+# the 1e-6 numerical tolerance on the upper bound (the sigmoid-based
+# bounding can approach but never exactly reach m).
 respects_constraint = bool(torch.all(c > 0) and torch.all(c <= m + 1e-6))
 
 # Property 2: the average propensity to consume c / m falls as the buffer

--- a/examples/algorithms/plot_train_against_known_solution.py
+++ b/examples/algorithms/plot_train_against_known_solution.py
@@ -27,15 +27,18 @@ below. Working in ratios to permanent income, the state is normalized assets
     V(m) = \max_{c} \; u(c) + \beta \, \mathbb{E}\!\left[ V(m') \right],
 
 with constant-relative-risk-aversion utility :math:`u` and discount factor
-:math:`\beta`. For this calibration the optimal policy is linear in
+:math:`\beta`. For this calibration the optimal policy is affine in
 cash-on-hand,
 
 .. math::
 
-    c^*(m) = \kappa \, m,
+    c^*(m) = \kappa \, (m + h),
 
-where the marginal propensity to consume :math:`\kappa` has a closed form. This
-gives us an exact target to check the trained policy against.
+where both the marginal propensity to consume :math:`\kappa = 1 - \beta` and
+the normalized human wealth :math:`h = 1/r` have closed forms. At this
+calibration :math:`h = 1/0.03 \approx 33.3`, so the intercept :math:`\kappa h`
+dominates and the consumption function is nearly flat over the training
+range. This gives us an exact target to check the trained policy against.
 
 Why a value head: the level-identification problem
 ===================================================

--- a/examples/models/plot_benchmark_models.py
+++ b/examples/models/plot_benchmark_models.py
@@ -20,8 +20,8 @@ bottom:
 #. **Consumption is a martingale.** Under :math:`\beta R = 1`, the *change* in
    consumption is the fundamental object, not its level. Income shocks of
    standard deviation :math:`\sigma_\eta` produce consumption changes of
-   standard deviation :math:`(r/R)\,\sigma_\eta` only, a factor of roughly 30x
-   smaller.
+   standard deviation :math:`(r/R)\,\sigma_\eta` only, a factor of
+   :math:`R/r \approx 34` smaller at this calibration.
 #. **Normalization collapses the state.** Dividing every level variable by
    permanent income turns a 2-D Bellman problem into a 1-D one. This trick is
    what makes neural-network solvers practical for richer models.
@@ -87,12 +87,15 @@ from skagent.models.benchmarks import (
 # Step 1: What's in the Registry
 # ------------------------------
 #
-# Five of the six entries carry an analytical policy that
+# Five of the seven entries carry an analytical policy that
 # ``validate_analytical_solution`` checks against the standard test grid.
 # U-3 is registered without one because the borrowing constraint plus
-# uncertainty break the linearity that every other entry relies on; the
-# helper still reports it as ``FAILED`` because no policy was found, not
-# because anything is wrong with the model.
+# uncertainty break the linearity that every other entry relies on, and
+# D-4 lacks one because its binding borrowing constraint forecloses a
+# closed form (its oracle is the value-function-iteration reference
+# policy from :py:func:`~skagent.models.benchmarks.get_reference_policy`).
+# The helper still reports both as ``FAILED`` because no analytical
+# policy was found, not because anything is wrong with the models.
 #
 # The registry itself records which models have a closed form, so the
 # distinction is queried with
@@ -207,7 +210,7 @@ fig.tight_layout()
 # no-mortality MPC :math:`\kappa`, and the wedge widens as :math:`s` falls.
 #
 # Sweeping :math:`s \in \{1.0, 0.95, 0.9, 0.8, 0.7\}` (median lifetime
-# falling from infinity to about 3 periods) makes the wedge visible. At
+# falling from infinity to about 2 periods) makes the wedge visible. At
 # :math:`s = 0.7` the agent consumes nearly six times more per dollar of
 # total wealth than at :math:`s = 1`. Empirical annual mortality at age 30
 # is around :math:`s = 0.999`, which is essentially indistinguishable from

--- a/examples/models/plot_resource_extraction.py
+++ b/examples/models/plot_resource_extraction.py
@@ -71,9 +71,9 @@ discounted expected continuation value.
 Parameters
 ----------
 
-- :math:`r` = 1.1: Growth rate (10% per period)
+- :math:`r` = 1.02: Growth rate (2% per period)
 - :math:`p` = 5.0: Price per unit extracted
-- :math:`c_0` = 2.0: Cost parameter for stock-dependent costs
+- :math:`c_0` = 10.0: Cost parameter for stock-dependent costs
 - :math:`\delta` (`DiscFac`) = 0.95: Discount factor for future rewards
 - :math:`\sigma` = 0.1: Standard deviation of log-normal growth shock
 

--- a/examples/simulation/README.rst
+++ b/examples/simulation/README.rst
@@ -1,6 +1,0 @@
-Simulation
------------
-
-This section demonstrates how to run simulations using scikit-agent models.
-These examples show how to generate synthetic data, run Monte Carlo simulations,
-and analyze the results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,11 @@ name = "scikit-agent"
 authors = [
   { name = "scikit-agent Team", email = "spb413@nyu.edu" },
 ]
-description = "A great package."
+description = "Specify, solve, and simulate dynamic stochastic optimization problems."
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
-  "Development Status :: 1 - Planning",
+  "Development Status :: 2 - Pre-Alpha",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
@@ -58,6 +58,7 @@ docs = [
   "myst_parser>=0.13",
   "sphinx_copybutton",
   "sphinx_autodoc_typehints",
+  "sphinx-autobuild",
   "furo>=2023.08.17",
   "sphinx-gallery",
   "sphinx-design",

--- a/src/skagent/models/benchmarks.py
+++ b/src/skagent/models/benchmarks.py
@@ -31,6 +31,8 @@ u(c)                : period utility function
 TVC                 : lim_{T→∞} E_0[β^T u'(c_T) A_T] = 0 (transversality condition)
 """
 
+from __future__ import annotations
+
 from skagent.distributions import Normal, MeanOneLogNormal, Bernoulli
 from skagent.block import Control, DBlock
 import copy

--- a/src/skagent/simulation/monte_carlo.py
+++ b/src/skagent/simulation/monte_carlo.py
@@ -2,8 +2,10 @@
 Functions to support Monte Carlo simulation of models.
 """
 
+from __future__ import annotations
+
 from copy import copy
-from typing import Mapping, Sequence
+from typing import Mapping, Sequence, Union
 
 import numpy as np
 
@@ -13,7 +15,7 @@ from skagent.distributions import (
     TimeVaryingDiscreteDistribution,
 )
 from skagent.block import Aggregate
-from skagent.block import DBlock
+from skagent.block import DBlock, RBlock
 from skagent.block import construct_shocks, simulate_dynamics
 
 
@@ -115,7 +117,7 @@ class Simulator:
     ----------
     calibration : Mapping[str, Any]
         Model calibration parameters
-    block : DBlock
+    block : DBlock or RBlock
         Has shocks, dynamics, and rewards
     dr : Mapping[str, Callable]
         Decision rules for control variables
@@ -132,7 +134,14 @@ class Simulator:
     state_vars = []
 
     def __init__(
-        self, calibration, block: DBlock, dr, initial, seed=0, agent_count=1, T_sim=10
+        self,
+        calibration,
+        block: Union[DBlock, RBlock],
+        dr,
+        initial,
+        seed=0,
+        agent_count=1,
+        T_sim=10,
     ):
         self.calibration = calibration
         self.block = block

--- a/src/skagent/solver.py
+++ b/src/skagent/solver.py
@@ -1,4 +1,5 @@
 import skagent.ann as ann
+import skagent.loss
 
 
 def solve_multiple_controls(
@@ -19,7 +20,7 @@ def solve_multiple_controls(
     """
 
     if loss is None:
-        loss = loss.StaticRewardLoss
+        loss = skagent.loss.StaticRewardLoss
 
     # Control policy networks for each control in the block.
     cpns = {}
@@ -41,9 +42,8 @@ def solve_multiple_controls(
         ann.train_block_nn(
             cpns[control_sym],
             givens,
-            loss(  # !!
+            loss(
                 bellman_period,
-                ["a"],  # !!
                 calibration,
                 dict_of_decision_rules,
             ),


### PR DESCRIPTION
## Summary

A correctness pass over `docs/`, the examples gallery, and the docs build, with the few source fixes the documentation claims depended on. Every corrected code snippet was executed against the package; the full test suite is green (326 passed, 32 subtests) and Sphinx builds clean under `-W --keep-going`.

## What was broken

**User-facing snippets crashed when run verbatim.**

- `index.md` and the quickstart called `simulate()` without `initialize_sim()` (RuntimeError) and paired `consumption_block` with `initial={"k": ...}`, but `k` is not a variable of that block (KeyError). Nothing in `consumption_block` maps `a` back to `k`; that is `tick_block`'s job inside `cons_problem`, which the examples now simulate.
- The quickstart built `BlockPolicyNet` from a raw `DBlock` (it takes a `BellmanPeriod`) and read a nonexistent `hidden1` attribute (`layers[0]` is correct).
- The parser API example used `gamma`, which SymPy parses as the gamma function, so the page's only example raised `TypeError`. Renamed to `rho` with a warning about SymPy name collisions.
- `blocks.md` live sections referenced `portfolio_block`, defined only inside an HTML comment; the habit/durables patterns used `h_prev`-style names that contradict the page's own arrival-state semantics, and the durables utility closed over an undefined `CRRA`.

**API reference gaps and drift.**

- `bellman`, `loss`, `distributions`, `rule`, `model_analyzer`/`model_visualizer` had no API pages; added (the `bellman` page surfaces the meta-model timing notation). Added missing entries for `BlockValueNet`, `BlockPolicyValueNet`, `train_block_nn`, and `get_reference_policy`. `skagent.solver` is deliberately left undocumented while it is WIP.
- `MonteCarloSimulator` was documented as a distinct "simplified" class; it is an alias of `Simulator`.
- `utils.md` demonstrated `Grid`, which lives in `skagent.grid`; replaced with runnable `apply_fun_to_vals` and `fischer_burmeister` examples.

**Quantitative claims contradicting the code.**

- `plot_resource_extraction.py` documented `r = 1.1`, `c_0 = 2.0`; the calibration is `1.02`, `10.0`, and the documented values violate the model's own impatience condition `delta * r < 1`.
- `plot_train_against_known_solution.py` stated the U-2 policy as `c* = kappa m`, omitting the human-wealth intercept (`c* = kappa (m + h)`, `h = 1/r`), which dominates at this calibration.
- The benchmark docs and gallery said six registry entries; there are seven (D-4 was undocumented). Also fixed a D-3 median-lifetime claim and the U-1 smoothing factor (R/r = 34, not "30x").

**Source fixes (small, doc-driven).**

- `solve_multiple_controls` default path dereferenced `None` and called the loss constructor with a stray positional argument. Fixed to resolve `skagent.loss.StaticRewardLoss` and match its signature. The function still has no tests or callers; its first real use should come with a benchmark-validated test.
- Importing `skagent.simulation.monte_carlo` or `skagent.models.benchmarks` on Python 3.9 raises `TypeError` (PEP 604 unions evaluated without `from __future__ import annotations`), contradicting `requires-python >= 3.9`; CI tests only 3.10/3.12 so this was invisible. Added the future imports. Also widened `Simulator`'s `block` hint to `Union[DBlock, RBlock]` to match documented usage.

**Consistency and infrastructure.**

- One name per concept: value backwards induction (VBI) per `algos/vbi.py`; "Maliar-style deep learning" with an all-in-one objective. The README no longer claims deep reinforcement learning (the roadmap places DDPG in the future).
- `sphinx-autobuild` added to the `docs` extra (`make livehtml` previously failed); `plot_gallery` is a bool; unused `autosummary_generate` removed; copyright year derived from build date; Read the Docs now builds with `-W --keep-going` like CI; the empty `examples/simulation/` gallery section removed; installation docs list the real dependency groups and Linux system libraries.
- PyPI metadata: placeholder description replaced; Development Status bumped to Pre-Alpha, matching the roadmap's v0.1 proof-of-concept claim.

## Suggested follow-up issues (not in this PR)

1. `Lognormal` takes the level mean/std, unlike HARK's log-space `(mu, sigma)`. `Lognormal(-6, 0)` is a point mass at negative six units of capital, and the test suite uses exactly that pattern for initial capital. Decide whether the degenerate branch should reject `mean <= 0`, gain an explicit `point_mass` constructor, or keep current semantics, and adjust the tests.
2. CI does not test Python 3.9 despite `requires-python >= 3.9`; the import crash fixed here would have been caught by a 3.9 leg. Either add 3.9 to the matrix or raise the floor.
3. `user_guide/algorithms.md` remains a stub; naming is now consistent but the page needs real content.

## Checklist

- [x] Tests added/updated (full suite green; no new code paths requiring tests beyond the noted follow-up)
- [x] Documentation updated
- [x] CHANGELOG.md updated (under `[Unreleased]` section)
- [x] Breaking changes noted in CHANGELOG if applicable (none)
