### PR TITLE
Return zero gradients for structurally independent variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Changed
 
+- `compute_gradients_for_tensors` returns a zero tensor (instead of `None`) for
+  a variable with no computational path to the target, and raises `ValueError`
+  when a `wrt` tensor does not require gradients; the `BellmanPeriod` gradient
+  methods (`grad_reward_function`, `grad_transition_function`,
+  `grad_pre_state_function`) inherit the tensor-only contract (#129)
+- Declared `torch >=2.0` as the minimum supported PyTorch version
 - Refactored `BellmanPeriod` with type hints, docstrings, and improved parameter
   handling
 - Introduced `_resolve_parameters`, `_resolve_decision_rules`, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "pyyaml",
   "scipy",
   "sympy",
-  "torch",
+  "torch >=2.0",
   "xarray",
 ]
 

--- a/src/skagent/bellman.py
+++ b/src/skagent/bellman.py
@@ -460,7 +460,7 @@ class BellmanPeriod:
         agent: str | None = None,
         decision_rules: dict[str, Callable] | None = None,
         create_graph: bool = False,
-    ) -> dict[str, dict[str, torch.Tensor | None]]:
+    ) -> dict[str, dict[str, torch.Tensor]]:
         """
         Compute gradients of reward function with respect to specified variables.
 
@@ -487,10 +487,10 @@ class BellmanPeriod:
 
         Returns
         -------
-        dict[str, dict[str, torch.Tensor | None]]
+        dict[str, dict[str, torch.Tensor]]
             Nested dictionary of gradients for each reward symbol and variable:
-            {reward_sym: {var_name: gradient}}. Gradient is None if the reward
-            does not depend on the variable.
+            {reward_sym: {var_name: gradient}}. The gradient is a zero tensor
+            when the reward does not depend on the variable.
         """
         shocks, decision_rules, parameters = self._resolve_inputs(
             shocks, decision_rules, parameters
@@ -520,7 +520,7 @@ class BellmanPeriod:
         parameters: dict[str, Any] | None = None,
         decision_rules: dict[str, Callable] | None = None,
         create_graph: bool = False,
-    ) -> dict[str, dict[str, torch.Tensor | None]]:
+    ) -> dict[str, dict[str, torch.Tensor]]:
         """
         Compute gradients of transition function with respect to specified variables.
 
@@ -550,9 +550,10 @@ class BellmanPeriod:
 
         Returns
         -------
-        dict[str, dict[str, torch.Tensor | None]]
+        dict[str, dict[str, torch.Tensor]]
             Nested dictionary of gradients for each arrival state and variable:
-            {state_sym: {var_name: gradient}}.
+            {state_sym: {var_name: gradient}}. The gradient is a zero tensor
+            when the arrival state does not depend on the variable.
         """
         # Use the existing transition_function method to compute next states
         next_states = self.transition_function(
@@ -577,7 +578,7 @@ class BellmanPeriod:
         parameters: dict[str, Any] | None = None,
         control_sym: str | None = None,
         create_graph: bool = False,
-    ) -> dict[str, dict[str, torch.Tensor | None]]:
+    ) -> dict[str, dict[str, torch.Tensor]]:
         """
         Compute gradients of pre-decision state variables with respect to arrival states.
 
@@ -618,9 +619,11 @@ class BellmanPeriod:
 
         Returns
         -------
-        dict[str, dict[str, torch.Tensor | None]]
+        dict[str, dict[str, torch.Tensor]]
             Nested dictionary of gradients for each pre-state variable and arrival state:
-            {pre_state_var: {state_sym: gradient}}.
+            {pre_state_var: {state_sym: gradient}}. The gradient is a zero
+            tensor when the pre-state variable does not depend on the
+            arrival state.
         """
         # Get the control's pre-state variables (stored as iset in the Control)
         if control_sym is None:
@@ -969,8 +972,8 @@ def estimate_bellman_residual(
 def _chain_rule_return_factor(
     bellman_period: BellmanPeriod,
     control_sym: str,
-    transition_gradients: dict[str, torch.Tensor | None],
-    pre_state_gradients: dict[str, dict[str, torch.Tensor | None]],
+    transition_gradients: dict[str, torch.Tensor],
+    pre_state_gradients: dict[str, dict[str, torch.Tensor]],
     like: torch.Tensor,
 ) -> torch.Tensor:
     r"""Sum the chain-rule product :math:`\sum_s \partial m'/\partial s' \cdot \partial s'/\partial c`.
@@ -993,16 +996,13 @@ def _chain_rule_return_factor(
 
     for state_sym in bellman_period.arrival_states:
         trans_grad = transition_gradients[state_sym]
-        if trans_grad is None:
-            logging.debug(
-                "Transition gradient d(%s)/d(%s) is None (no computational path). "
-                "If unexpected, check that control '%s' tensors require_grad.",
-                state_sym,
-                control_sym,
-                control_sym,
-            )
+        if not torch.any(trans_grad != 0):
+            # An all-zero transition gradient means the arrival state is
+            # independent of the control; skipping the term also avoids
+            # 0 * Inf = NaN from an ill-conditioned pre-state factor.
             continue
         for state_grads in pre_state_gradients.values():
+            # .get guards arrival states absent from the wrt dict
             pre_state_grad = state_grads.get(state_sym)
             if pre_state_grad is not None:
                 total = total + pre_state_grad * trans_grad
@@ -1066,10 +1066,11 @@ def _euler_residual_single_control(
         create_graph=True,
     )
     marginal_reward_t = grads_t[reward_sym][control_sym]
-    if marginal_reward_t is None:
+    if not torch.any(marginal_reward_t != 0):
         raise ValueError(
-            f"Could not compute marginal reward at period t: "
-            f"reward '{reward_sym}' does not depend on control '{control_sym}'"
+            f"Marginal reward at period t is zero at every sample point: "
+            f"reward '{reward_sym}' is structurally independent of control "
+            f"'{control_sym}', or its gradient vanishes on the whole batch"
         )
 
     # ∂u/∂c at period t+1
@@ -1083,10 +1084,11 @@ def _euler_residual_single_control(
         create_graph=True,
     )
     marginal_reward_t1 = grads_t1[reward_sym][control_sym]
-    if marginal_reward_t1 is None:
+    if not torch.any(marginal_reward_t1 != 0):
         raise ValueError(
-            f"Could not compute marginal reward at period t+1: "
-            f"reward '{reward_sym}' does not depend on control '{control_sym}'"
+            f"Marginal reward at period t+1 is zero at every sample point: "
+            f"reward '{reward_sym}' is structurally independent of control "
+            f"'{control_sym}', or its gradient vanishes on the whole batch"
         )
 
     # Transition gradients: ∂s_{t+1}/∂c_t for all arrival states.
@@ -1322,10 +1324,11 @@ def estimate_bellman_foc_residual(
             create_graph=True,
         )
         mr_t = reward_grads[reward_sym][control_sym]
-        if mr_t is None:
+        if not torch.any(mr_t != 0):
             raise ValueError(
-                f"Could not compute marginal reward: "
-                f"reward '{reward_sym}' does not depend on control '{control_sym}'"
+                f"Marginal reward is zero at every sample point: "
+                f"reward '{reward_sym}' is structurally independent of control "
+                f"'{control_sym}', or its gradient vanishes on the whole batch"
             )
 
         # s' = f(s, c, ε₀) — transition preserving autograd graph through c_t

--- a/src/skagent/utils.py
+++ b/src/skagent/utils.py
@@ -154,7 +154,7 @@ def compute_gradients_for_tensors(
     tensors_dict: dict[str, torch.Tensor],
     wrt: dict[str, torch.Tensor],
     create_graph: bool = False,
-) -> dict[str, dict[str, torch.Tensor | None]]:
+) -> dict[str, dict[str, torch.Tensor]]:
     """
     Compute gradients for a dictionary of tensors with respect to variables.
 
@@ -186,32 +186,48 @@ def compute_gradients_for_tensors(
 
     Returns
     -------
-    dict[str, dict[str, torch.Tensor | None]]
+    dict[str, dict[str, torch.Tensor]]
         Nested dictionary of gradients for each tensor symbol and variable:
-        ``{tensor_sym: {var_name: gradient}}``. Gradient is ``None`` if and
-        only if the variable does not require gradients or no computational
-        graph path exists from the variable to the target tensor. A zero
-        tensor is returned when the dependency exists but evaluates to zero.
-        Callers should treat ``None`` as structural independence, not as a
-        zero gradient.
-    """
-    from torch.autograd import grad
+        ``{tensor_sym: {var_name: gradient}}``. A variable with no
+        computational graph path to the target receives a zero tensor,
+        which is the value of the partial derivative under structural
+        independence.
 
-    gradients: dict[str, dict[str, torch.Tensor | None]] = {}
+    Raises
+    ------
+    ValueError
+        If a ``wrt`` tensor does not have ``requires_grad=True``.
+    """
+    for var_name, var_tensor in wrt.items():
+        if not var_tensor.requires_grad:
+            raise ValueError(
+                f"Variable '{var_name}' in wrt does not require gradients. "
+                "Set requires_grad=True on the tensor before differentiating."
+            )
+
+    def _zeros(var_tensor: torch.Tensor) -> torch.Tensor:
+        # Under create_graph=True the zero must stay graph-connected so
+        # higher-order differentiation through it remains possible.
+        return var_tensor * 0 if create_graph else torch.zeros_like(var_tensor)
+
+    gradients: dict[str, dict[str, torch.Tensor]] = {}
     for tensor_sym, target_tensor in tensors_dict.items():
         gradients[tensor_sym] = {}
         for var_name, var_tensor in wrt.items():
-            if not var_tensor.requires_grad:
-                gradients[tensor_sym][var_name] = None
+            if not target_tensor.requires_grad:
+                # The target has no graph at all, so every partial is zero.
+                gradients[tensor_sym][var_name] = _zeros(var_tensor)
                 continue
 
-            grad_result = grad(
+            grad_result = torch.autograd.grad(
                 target_tensor.sum(),
                 var_tensor,
                 retain_graph=True,
                 create_graph=create_graph,
                 allow_unused=True,
-            )
-            gradients[tensor_sym][var_name] = grad_result[0]
+            )[0]
+            if grad_result is None:
+                grad_result = _zeros(var_tensor)
+            gradients[tensor_sym][var_name] = grad_result
 
     return gradients

--- a/tests/test_bellman.py
+++ b/tests/test_bellman.py
@@ -6,6 +6,8 @@ import skagent.block as model
 import torch
 import unittest
 
+torch.manual_seed(10077696)
+
 # Deterministic test seed - change this single value to modify all seeding
 TEST_SEED = 10077693
 
@@ -293,7 +295,8 @@ class TestGradRewardFunction(unittest.TestCase):
             states_t, controls_t, {"c": c, "a": a}
         )
 
-        # For u = log(c), du/dc = 1/c, du/da = 0 (unused variable)
+        # For u = log(c), du/dc = 1/c; du/da = 0 because u is structurally
+        # independent of a once the control is held fixed
         expected_grad_c = 1.0 / c
 
         self.assertIn("u", gradients)
@@ -301,7 +304,7 @@ class TestGradRewardFunction(unittest.TestCase):
         self.assertIn("a", gradients["u"])
 
         self.assertTrue(torch.allclose(gradients["u"]["c"], expected_grad_c, atol=1e-6))
-        self.assertIsNone(gradients["u"]["a"])  # Unused variable returns None
+        self.assertTrue(torch.equal(gradients["u"]["a"], torch.zeros_like(a)))
 
     def test_get_grad_reward_function_multiple_rewards(self):
         """Test gradients for multiple rewards."""
@@ -322,9 +325,9 @@ class TestGradRewardFunction(unittest.TestCase):
         self.assertTrue(
             torch.allclose(gradients["u1"]["c1"], expected_grad_u1_c1, atol=1e-6)
         )
-        self.assertIsNone(gradients["u1"]["c2"])  # u1 doesn't depend on c2
-
-        self.assertIsNone(gradients["u2"]["c1"])  # u2 doesn't depend on c1
+        # u1 does not depend on c2, and u2 does not depend on c1
+        self.assertTrue(torch.equal(gradients["u1"]["c2"], torch.zeros_like(c2)))
+        self.assertTrue(torch.equal(gradients["u2"]["c1"], torch.zeros_like(c1)))
         self.assertTrue(
             torch.allclose(gradients["u2"]["c2"], expected_grad_u2_c2, atol=1e-6)
         )
@@ -375,21 +378,69 @@ class TestGradRewardFunction(unittest.TestCase):
         )
 
     def test_get_grad_reward_function_error_handling(self):
-        """Test error handling and edge cases."""
-        # Test with variable that doesn't require gradients
+        """A wrt variable without requires_grad raises ValueError."""
         c_no_grad = torch.tensor(0.5, requires_grad=False)
         a = torch.tensor(1.0, requires_grad=True)
 
         states_t = {"a": a}
         controls_t = {"c": c_no_grad}
-        wrt = {"c": c_no_grad}  # This should handle gracefully
+        wrt = {"c": c_no_grad}
 
-        # This should work but return None gradients
-        gradients = self.simple_bp.grad_reward_function(states_t, controls_t, wrt)
-        self.assertIn("u", gradients)
-        self.assertIn("c", gradients["u"])
-        # Gradient should be None for tensor without requires_grad=True
-        self.assertIsNone(gradients["u"]["c"])
+        with self.assertRaises(ValueError):
+            self.simple_bp.grad_reward_function(states_t, controls_t, wrt)
+
+    def test_zero_transition_gradient_masks_nonfinite_pre_state(self):
+        """An all-zero transition gradient skips its chain-rule term, so a
+        non-finite pre-state factor on that path cannot inject NaN."""
+        block = model.DBlock(
+            name="two_state",
+            dynamics={
+                "c": model.Control(["a"]),
+                "a": lambda a, c: a - c,
+                "b": lambda b: 0.9 * b,
+                "u": lambda c: torch.log(c),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+
+        like = torch.ones(3)
+        transition_gradients = {"a": -torch.ones(3), "b": torch.zeros(3)}
+        pre_state_gradients = {
+            "m": {"a": 1.05 * torch.ones(3), "b": torch.full((3,), float("inf"))}
+        }
+
+        total = bellman._chain_rule_return_factor(
+            bp, "c", transition_gradients, pre_state_gradients, like
+        )
+
+        self.assertTrue(torch.allclose(total, -1.05 * torch.ones(3), atol=1e-7))
+
+    def test_grad_reward_composes_through_intermediates(self):
+        """The reward gradient flows through intermediate dynamics (#129)."""
+        block = model.DBlock(
+            name="indirect_reward",
+            dynamics={
+                "m": lambda a: 1.05 * a,
+                "c": model.Control(["m"]),
+                "u": lambda m, c: torch.log(m - 0.5 * c),
+            },
+            reward={"u": "consumer"},
+        )
+        bp = bellman.BellmanPeriod(block, "beta", {"beta": 0.9})
+        a = torch.tensor(1.0, requires_grad=True)
+        c = torch.tensor(0.5, requires_grad=True)
+
+        gradients = bp.grad_reward_function({"a": a}, {"c": c}, {"c": c, "a": a})
+
+        # u = log(1.05 * a - 0.5 * c), so du/da = 1.05 / 0.8 = 1.3125
+        # and du/dc = -0.5 / 0.8 = -0.625 at (a, c) = (1.0, 0.5)
+        self.assertTrue(
+            torch.allclose(gradients["u"]["a"], torch.tensor(1.3125), atol=1e-7)
+        )
+        self.assertTrue(
+            torch.allclose(gradients["u"]["c"], torch.tensor(-0.625), atol=1e-7)
+        )
 
 
 class TestGradTransitionFunction(unittest.TestCase):

--- a/tests/test_bellman.py
+++ b/tests/test_bellman.py
@@ -6,8 +6,6 @@ import skagent.block as model
 import torch
 import unittest
 
-torch.manual_seed(10077696)
-
 # Deterministic test seed - change this single value to modify all seeding
 TEST_SEED = 10077693
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,6 @@ import skagent.utils as utils
 import torch
 from skagent.utils import compute_gradients_for_tensors
 
-torch.manual_seed(10077696)
-
 
 def test_utils_apply_fun_to_vals():
     def pow(x, y):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,8 @@ import skagent.utils as utils
 import torch
 from skagent.utils import compute_gradients_for_tensors
 
+torch.manual_seed(10077696)
+
 
 def test_utils_apply_fun_to_vals():
     def pow(x, y):
@@ -78,23 +80,40 @@ class TestComputeGradientsForTensors(unittest.TestCase):
         grads = compute_gradients_for_tensors({"y": target}, {"x": x})
         self.assertTrue(torch.allclose(grads["y"]["x"], 2.0 * x, atol=1e-6))
 
-    def test_no_grad_returns_none(self):
-        """Variable without requires_grad should produce None."""
+    def test_no_grad_raises(self):
+        """A wrt variable without requires_grad raises ValueError."""
         x = torch.tensor(3.0, requires_grad=False)
         y = torch.tensor(5.0, requires_grad=True)
         target = y**2
-        grads = compute_gradients_for_tensors({"t": target}, {"x": x, "y": y})
-        self.assertIsNone(grads["t"]["x"])
-        self.assertIsNotNone(grads["t"]["y"])
+        with self.assertRaises(ValueError):
+            compute_gradients_for_tensors({"t": target}, {"x": x, "y": y})
 
-    def test_unused_variable_returns_none(self):
-        """Variable not used in computation should produce None."""
+    def test_unused_variable_returns_zeros(self):
+        """A variable with no path to the target gets a zero gradient."""
+        x = torch.tensor(3.0, requires_grad=True)
+        y = torch.tensor([5.0, 6.0], requires_grad=True)
+        target = x**2  # the target is structurally independent of y
+        grads = compute_gradients_for_tensors({"t": target}, {"x": x, "y": y})
+        self.assertTrue(torch.allclose(grads["t"]["x"], 2.0 * x, atol=1e-6))
+        self.assertTrue(torch.equal(grads["t"]["y"], torch.zeros_like(y)))
+
+    def test_constant_target_returns_zeros(self):
+        """A target with no computational graph yields zero gradients."""
+        x = torch.tensor(3.0, requires_grad=True)
+        target = torch.tensor(7.0)
+        grads = compute_gradients_for_tensors({"t": target}, {"x": x})
+        self.assertTrue(torch.equal(grads["t"]["x"], torch.zeros_like(x)))
+
+    def test_unused_zero_supports_higher_order(self):
+        """With create_graph=True a structural zero stays differentiable."""
         x = torch.tensor(3.0, requires_grad=True)
         y = torch.tensor(5.0, requires_grad=True)
-        target = x**2  # y is unused
-        grads = compute_gradients_for_tensors({"t": target}, {"x": x, "y": y})
-        self.assertIsNotNone(grads["t"]["x"])
-        self.assertIsNone(grads["t"]["y"])
+        target = x**2
+        grads = compute_gradients_for_tensors(
+            {"t": target}, {"x": x, "y": y}, create_graph=True
+        )
+        second = torch.autograd.grad(grads["t"]["y"].sum(), y)[0]
+        self.assertTrue(torch.equal(second, torch.zeros_like(y)))
 
     def test_create_graph_enables_higher_order(self):
         """create_graph=True should allow second-order derivatives."""


### PR DESCRIPTION
Follows up on #129, where the open question was the return contract of the gradient utilities. The utility `compute_gradients_for_tensors` now returns a zero tensor when a `wrt` variable has no computational path to the target, since zero is the value of the partial derivative under structural independence; passing a tensor without `requires_grad=True` raises `ValueError` instead of silently producing `None`. Under `create_graph=True` the materialized zeros stay graph-connected, so higher-order differentiation through them still works. The `BellmanPeriod` gradient methods inherit the tensor-only contract.

Two consumer updates follow from this. The Euler and FOC diagnostics now raise when the marginal reward is zero at every sample point, and the chain-rule return factor skips arrival states whose transition gradient is all zero, so a non-finite pre-state factor cannot turn `0 * Inf` into `NaN` where the old `None` path used to skip the term.

New regression tests pin the composed-reward gradient against analytic values (the substantive guarantee from #129), second-order differentiation through a structural zero, and the `NaN`-masking path. The PR also declares `torch >=2.0` as the minimum supported PyTorch version.
