### PR TITLE
Bilateral Fischer-Burmeister constraints and a Maliar method user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to
   policy-network transforms, the bilateral Fischer-Burmeister complementarity
   loss, how the mechanisms compose, and VBI's box-constraint handling, with a
   table of where each mechanism is available (#191).
+- **Maliar method** user-guide page explaining the all-in-one expectation
+  operator, the Euler and Bellman residual losses (and the slope-versus-level
+  identification difference between them), `maliar_training_loop`, and how
+  bounded controls connect to the constraints page (#215). The Algorithms guide
+  now links to it and its duplicate "Solving a block directly" heading is
+  retitled to "Overview".
 - `fischer_burmeister(a, h)` utility for smooth complementarity conditions
 - `examples/algorithms/plot_train_against_known_solution.py` gallery example
   (renamed from `plot_maliar_training.py`): trains a shared-backbone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ and this project adheres to
 - `EulerEquationLoss` no longer takes a `discount_factor` parameter; the
   discount factor is now resolved from `bellman_period.discount_variable`
 - `EulerEquationLoss` constrained mode uses the Fischer-Burmeister function
-  (equation 25) when controls have an `upper_bound` defined
+  (equation 25) for both the lower-bound and upper-bound sides of the
+  complementarity condition. A control with an `upper_bound` uses
+  `FB(f, ub - x)`, a `lower_bound` uses `FB(-f, x - lb)`, and a control with
+  both uses a two-sided form that reduces to either one-sided residual when the
+  opposite bound is slack (#191)
 - `EulerEquationLoss` now estimates the squared expected Euler residual with the
   all-in-one operator: the _product_ of two residuals at independent next-period
   shock draws (Maliar, Maliar, and Winant 2021, JME), rather than the square of
@@ -38,8 +42,10 @@ and this project adheres to
   unchanged.
 - `estimate_euler_residual` resolves the discount factor dynamically from the
   model and supports multi-control models (returns a dict for >1 controls)
-- Control bounds (`lower_bound`, `upper_bound`) must now be callables; numeric
-  values raise a clear `TypeError` instead of being silently ignored.
+- Control bounds (`lower_bound`, `upper_bound`) accept either a number (a
+  constant bound) or a callable of the control's information-set variables.
+  Numbers are normalized to zero-argument callables at the `Control` boundary,
+  so every downstream consumer sees a uniform callable interface (#191).
 - Introduced `mortality_block` (and `mortal_cons_problem`) to demonstrate how to
   encode stochastic mortality and agent rebirth as a composable `DBlock`.
 - `train_block_nn` now always returns a 3-tuple
@@ -82,10 +88,9 @@ and this project adheres to
   deliberate discount-folded-into-continuation path).
 - **Constraints** user-guide page documenting the ways to constrain an
   optimization problem: bound declaration on `Control`, the open-bounds
-  policy-network transforms, the Fischer-Burmeister complementarity loss
-  (including its current upper-bound-only scope), how the mechanisms compose,
-  and VBI's box-constraint handling (#191). The `blocks.md` portfolio example
-  now passes callable bounds, matching the enforced API.
+  policy-network transforms, the bilateral Fischer-Burmeister complementarity
+  loss, how the mechanisms compose, and VBI's box-constraint handling, with a
+  table of where each mechanism is available (#191).
 - `fischer_burmeister(a, h)` utility for smooth complementarity conditions
 - `examples/algorithms/plot_train_against_known_solution.py` gallery example
   (renamed from `plot_maliar_training.py`): trains a shared-backbone

--- a/docs/user_guide/algorithms.md
+++ b/docs/user_guide/algorithms.md
@@ -3,17 +3,15 @@
 This guide covers the solution algorithms and optimization methods available in
 scikit-agent.
 
-## Solving a block directly
+## Overview
 
-A {doc}`block <blocks>` describes a single decision period: arrival states and
-shocks come in, the agent chooses its controls, and a reward is produced. The
-most direct use of the deep-learning solver is to train a
-{py:class}`~skagent.ann.BlockPolicyNet` so that its decision rule maximizes the
-reward earned within the block, over a grid of starting points.
+scikit-agent offers several ways to turn a {doc}`block <blocks>` into a decision
+rule. Which one fits depends on whether the problem is a single period, a fixed
+horizon, or a recurring problem with a continuation value:
 
 - **Maliar-style deep learning methods**: Neural network solvers following
-  Maliar, Maliar, and Winant (2021), which train on an all-in-one (AiO)
-  objective function
+  Maliar, Maliar, and Winant (2021), which train on an all-in-one objective; see
+  {doc}`maliar`
 - **Value backwards induction (VBI)**: Classical dynamic programming via
   backwards induction on a grid
 - **Reinforcement Learning**: Learn a policy by trial-and-error interaction with
@@ -268,7 +266,8 @@ induction over a block's value function. See {py:func}`skagent.algos.vbi.solve`.
 The neural Bellman- and Euler-equation losses
 ({py:class}`~skagent.loss.BellmanEquationLoss`,
 {py:class}`~skagent.loss.EulerEquationLoss`) provide deep-learning alternatives
-for the recurring case.
+for the recurring case; the {doc}`Maliar method <maliar>` page explains those
+losses and the training loop that fits them.
 
 ## Performance Considerations
 

--- a/docs/user_guide/blocks.md
+++ b/docs/user_guide/blocks.md
@@ -117,14 +117,14 @@ a dynamic equation, the modeler specifies an information set -- what information
 #### Constraints
 
 Control variables can be upper and lower bound to values that are themselves
-functions of state variables. Each bound is a callable; a constant bound is a
-zero-argument callable.
+functions of state variables. Each bound is a number (a constant bound) or a
+callable of variables in the control's information set.
 
 ```python
 consumption_control = ska.Control(
     iset=["m", "p"],  # Information set
-    lower_bound=lambda: 0.001,  # Minimum consumption
-    upper_bound=lambda m: 0.99 * m,  # Maximum consumption
+    lower_bound=0.001,  # Minimum consumption (constant)
+    upper_bound=lambda m: 0.99 * m,  # Maximum consumption (state-dependent)
     agent="consumer",  # Agent assignment
 )
 ```
@@ -259,7 +259,7 @@ dynamics = {
     "m": lambda b, y: b + y,
     # Decisions (controls)
     "c": ska.Control(["m"], upper_bound=lambda m: m),
-    "alpha": ska.Control(["a"], lower_bound=lambda: 0.0, upper_bound=lambda: 1.0),
+    "alpha": ska.Control(["a"], lower_bound=0.0, upper_bound=1.0),
     # End-of-period states
     "a": lambda m, c: m - c,
     # Utility

--- a/docs/user_guide/constraints.md
+++ b/docs/user_guide/constraints.md
@@ -1,42 +1,41 @@
 # Constraining an Optimization Problem
 
-Most dynamic programs worth solving constrain their decisions. An agent who can
-choose any value of a control faces a different, and often degenerate, problem
-from one whose choice must stay inside a feasible set; for example, a consumer
-who cannot borrow solves a genuinely harder problem than one who can. For
-gradient-based solvers the constraint is a complication in its own right:
-training a neural network means differentiating through the policy, and a hard
-constraint introduces exactly the kind of kink that gradients handle badly.
+Most dynamic programs constrain their decisions: a consumer cannot borrow more
+than a credit limit, a portfolio share must stay between zero and one. This page
+shows how to declare those bounds in scikit-agent and which solvers enforce
+them.
 
-scikit-agent addresses this with one declaration and two enforcement mechanisms.
-Bounds are declared once, on the {py:class}`~skagent.block.Control` object. A
-policy network can then build feasibility into its output layer, and a training
-loss can encode the optimality conditions that hold where the constraint binds.
-The two mechanisms answer different questions. The first guarantees that every
-candidate policy is feasible; the second teaches the solver where the constraint
-should bind. They compose, and for problems with binding constraints they work
-best together.
+You declare a bound once, on the {py:class}`~skagent.block.Control` object. From
+that single declaration two mechanisms act, and they answer different questions:
+
+- a **policy network** can build feasibility into its output layer, so every
+  candidate policy it proposes is feasible;
+- a **training loss** can encode the optimality condition that holds where a
+  constraint binds.
+
+The two are independent. You can use the network bounds alone, and for many
+problems that is enough. The loss-side condition is currently available on one
+loss, {py:class}`~skagent.loss.EulerEquationLoss`, and matters when you train on
+an Euler objective and the constraint actually binds.
 
 ## Declaring Bounds
 
-Each bound on a {py:class}`~skagent.block.Control` is a callable whose argument
-names refer to variables in the control's information set. A constant bound is a
-zero-argument callable.
+A bound on a {py:class}`~skagent.block.Control` is either a number or a callable
+whose argument names are variables in the control's information set. A number is
+a constant bound; a callable is a state-dependent one. Either side may be
+omitted, leaving the control unbounded on that side.
 
 ```python
 c = ska.Control(
     ["m"],
-    lower_bound=lambda: 1e-3,
-    upper_bound=lambda m: m,
+    lower_bound=1e-3,  # constant floor
+    upper_bound=lambda m: m,  # state-dependent ceiling
 )
 ```
 
-For example, this declares a decision $c$ that must stay between a small
-positive floor and the pre-decision state $m$; in a consumption-saving model the
-upper bound is a borrowing constraint. Either bound may be omitted, in which
-case the control is unbounded on that side. Passing a raw number such as
-`upper_bound=1.0` raises a `TypeError` when a policy network is built from the
-block; write `lambda: 1.0` instead. Everything below reads this single
+This declares a decision $c$ that must stay between a small positive floor and
+the pre-decision state $m$. In a consumption-saving model the upper bound
+$c \le m$ is a no-borrowing constraint. Everything below reads this one
 declaration, so a model never states its constraints twice.
 
 ## Feasibility by Construction: Bounded Policy Networks
@@ -57,19 +56,17 @@ which bounds the control declares:
 
 Here $\sigma$ is the logistic sigmoid and
 $\operatorname{softplus}(z) = \log(1 + e^z)$. The bounds are _open_: the output
-approaches but never equals either endpoint, which is why the mechanism is
-called open-bounds scaling. The payoff is robustness. Every policy the optimizer
-visits is feasible, so a reward like $\log(c)$ is never evaluated at an
-infeasible point mid-training. The limitation is that the transform carries no
-information about _whether_ the constraint should bind; a policy can hug a bound
-without the loss ever being told that a Lagrange multiplier belongs there. The
-transform is on by default and can be disabled with `apply_open_bounds=False`.
+approaches but never equals either endpoint, so a reward like $\log(c)$ is never
+evaluated at an infeasible point mid-training. What the transform does _not_ do
+is signal whether a constraint should bind; a policy can hug a bound without the
+loss being told a Lagrange multiplier belongs there. The transform is on by
+default and can be disabled with `apply_open_bounds=False`.
 
 ## Optimality at the Bound: Fischer-Burmeister Complementarity
 
 Where a constraint binds, the first-order condition changes. With an Euler
-residual $f$ and constraint slack $s = \overline{x} - x$, optimality requires
-the complementarity conditions
+residual $f$ and an upper-bound slack $s = \overline{x} - x$, optimality is the
+complementarity condition
 
 $$
 f \geq 0, \qquad s \geq 0, \qquad f \cdot s = 0,
@@ -78,59 +75,89 @@ $$
 so the residual need not vanish at the bound; the slack must. The equivalent
 equation $\min(f, s) = 0$ is not differentiable, which is the wrong shape for a
 training loss. Following equation (25) of Maliar, Maliar, and Winant (2021),
-{py:func}`~skagent.utils.fischer_burmeister` replaces it with the smooth
-Fischer-Burmeister function
+{py:func}`~skagent.utils.fischer_burmeister` replaces it with
 
 $$
-\operatorname{FB}(f, s) = f + s - \sqrt{f^2 + s^2} = 0,
+\operatorname{FB}(f, s) = f + s - \sqrt{f^2 + s^2 + \varepsilon},
 $$
 
-which is zero exactly where the complementarity conditions hold and
-differentiable everywhere. Setting `constrained=True` on
-{py:class}`~skagent.loss.EulerEquationLoss` builds this residual for every
-control that declares an `upper_bound`:
+which is zero (up to $\sqrt{\varepsilon}$) exactly where the complementarity
+conditions hold. The small $\varepsilon$ under the root is a numerical
+regularizer: it keeps the gradient finite at $f = s = 0$, so the residual is
+differentiable everywhere, at the cost of
+$\operatorname{FB}(0, 0) =
+-\sqrt{\varepsilon}$ rather than exactly zero. With
+the default $\varepsilon = 10^{-12}$ this offset is about $10^{-6}$, below
+typical convergence tolerances but worth accounting for in a very tight test.
+
+Set `constrained=True` on {py:class}`~skagent.loss.EulerEquationLoss` to build
+this residual:
 
 ```python
 loss = EulerEquationLoss(bellman_period, constrained=True)
 ```
 
-The squared expected residual is estimated in all-in-one fashion as the product
-$\operatorname{FB}(f_a, s) \cdot \operatorname{FB}(f_b, s)$ at two independent
-next-period shock draws, which keeps the estimate unbiased. A control without an
-explicit `upper_bound` falls back to the one-sided penalty
-$\operatorname{relu}(-f_a) \cdot \operatorname{relu}(-f_b)$, which punishes only
-violations of $f \geq 0$.
+The loss reads each control's declared bounds and forms the complementarity
+residual that matches them:
 
-One scope restriction is worth stating plainly: the constrained loss currently
-models the upper-bound side of the complementarity condition only. A
-`lower_bound` declared on a `Control` is respected by the network transform
-above, but it does not yet enter the complementarity residual; bilateral support
-requires flipping the residual sign for lower-binding cases
-($\operatorname{FB}(-f, x - \underline{x})$) and is left as a follow-up.
+- upper bound only: $\operatorname{FB}(f,\; \overline{x} - x)$;
+- lower bound only: $\operatorname{FB}(-f,\; x - \underline{x})$, the residual
+  sign flipping because a binding lower bound pushes the decision the other way;
+- both bounds: a two-sided form,
+  $\operatorname{FB}\!\big(\overline{x} - x,\; -\operatorname{FB}(x -
+  \underline{x},\; -f)\big)$,
+  which reduces to either one-sided residual when the opposite bound is slack;
+- no bound: a one-sided penalty $\operatorname{relu}(-f)$ on violations of
+  $f \geq 0$.
+
+The squared expected residual is estimated in all-in-one fashion as the product
+of the residuals at two independent next-period shock draws, which keeps the
+estimate unbiased.
 
 ## Using Both Together
 
-The mechanisms are complementary rather than competing. The bounded network
-keeps every training iterate feasible; the Fischer-Burmeister loss supplies the
-optimality condition that tells the solver where the bound binds and by how
-much. The constrained perfect-foresight benchmark (`D-4` in the
+The mechanisms compose: the bounded network keeps every training iterate
+feasible, while the Fischer-Burmeister loss supplies the optimality condition at
+the bound. A minimal Euler-method setup on a constrained consumption-saving
+block looks like this:
+
+```python
+import skagent as ska
+from skagent.ann import BlockPolicyNet, train_block_nn
+from skagent.loss import EulerEquationLoss
+
+# c is bounded below by a floor and above by the no-borrowing ceiling c <= m.
+bellman_period = ska.BellmanPeriod(block, "DiscFac", calibration)
+
+policy_net = BlockPolicyNet(bellman_period)  # feasible by construction
+euler_loss = EulerEquationLoss(
+    bellman_period, constrained=True
+)  # bound-aware optimality
+
+policy_net, _, _ = train_block_nn(policy_net, train_grid, euler_loss, epochs=1)
+```
+
+The constrained perfect-foresight benchmark (`D-4` in the
 {doc}`benchmark_models` registry) is the in-package demonstration: a policy
-network trained on `EulerEquationLoss(constrained=True)` matches a
-value-function-iteration oracle to well within one percent on average, on a
-problem whose borrowing constraint binds at low wealth and where an
-unconstrained Euler objective cannot identify the policy level at all. For a
-runnable walkthrough on the buffer-stock model, see
+network trained this way matches a value-function-iteration oracle to well
+within one percent on average, on a problem whose borrowing constraint binds at
+low wealth and where an unconstrained Euler objective cannot identify the policy
+level at all. For a runnable walkthrough, see
 {doc}`../auto_examples/algorithms/plot_maliar_training_loop`.
 
 A practical rule of thumb: if the constraint cannot bind in the region of the
-state space you care about, the default network bounds are enough. If it can
-bind and you train on an Euler or first-order-condition objective, add
-`constrained=True` so the loss knows what optimality looks like at the boundary.
+state space you care about, the network bounds alone are enough. If it can bind
+and you train on an Euler objective, add `constrained=True`.
 
-## Grid Solvers
+## Where Each Mechanism Is Available
 
-Constraint handling is not specific to neural methods. The value backwards
-induction solver ({py:mod}`skagent.algos.vbi`) reads the same `Control` bounds
-and passes them to `scipy.optimize.minimize` as box constraints on each grid
-point's optimization, with no smooth reformulation needed because no gradient
-flows through the policy.
+| Mechanism            | Where it lives                                  | Bounds handled  |
+| -------------------- | ----------------------------------------------- | --------------- |
+| Open-bounds network  | `BlockPolicyNet`, `BlockPolicyValueNet`         | lower and upper |
+| Complementarity loss | `EulerEquationLoss(constrained=True)`           | lower and upper |
+| Grid box constraints | `skagent.algos.vbi` (value backwards induction) | lower and upper |
+
+The value backwards induction solver ({py:mod}`skagent.algos.vbi`) reads the
+same `Control` bounds and passes them to `scipy.optimize.minimize` as box
+constraints, with no smooth reformulation needed because no gradient flows
+through the policy.

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -35,6 +35,7 @@ Learn about the fundamental concepts and components:
 - {doc}`blocks` - Understanding model structure and building custom models
 - {doc}`simulation` - Monte Carlo simulation and analysis
 - {doc}`algorithms` - Solution methods for solving your models
+- {doc}`maliar` - Neural-network solution via the Maliar method
 - {doc}`environments` - Interactive adapters for reinforcement-learning
   algorithms
 - {doc}`constraints` - The ways to constrain decisions and how solvers enforce
@@ -74,6 +75,7 @@ quickstart
 blocks
 simulation
 algorithms
+maliar
 environments
 constraints
 benchmark_models

--- a/docs/user_guide/maliar.md
+++ b/docs/user_guide/maliar.md
@@ -1,0 +1,153 @@
+# Solving Models with the Maliar Method
+
+Many dynamic programs have no closed-form solution, and discretizing the state
+space scales badly as states accumulate. The Maliar method (Maliar, Maliar, and
+Winant 2021) sidesteps both problems: it represents the decision rule as a
+neural network and turns the search for a policy into the minimization of an
+equation-residual loss over a sample of states. This page explains what the
+method minimizes, the two residual losses scikit-agent provides, and how to run
+the training loop.
+
+## The All-in-One Expectation Operator
+
+A dynamic optimality condition holds in expectation over next period's shocks.
+Write $f$ for the residual of that condition, the quantity that is zero when the
+policy is optimal. We want to drive the squared expected residual
+$(\mathbb{E}[f])^2$ to zero across the sampled states.
+
+The obvious estimator, squaring a single simulated residual, is biased. Because
+$\mathbb{E}[f^2] = (\mathbb{E}[f])^2 + \mathrm{Var}(f)$, minimizing it rewards a
+policy for suppressing the residual's sampling noise rather than for satisfying
+the condition in expectation, and that extra variance term distorts the solution
+of any stochastic model. The Maliar method instead draws two independent shock
+realizations, evaluates the residual at each while holding the current control
+fixed, and multiplies the two. Writing $f_a$ and $f_b$ for the residuals at the
+two draws, independence gives
+
+$$
+\mathbb{E}[f_a\, f_b] = \mathbb{E}[f_a]\,\mathbb{E}[f_b] = (\mathbb{E}[f])^2,
+$$
+
+so the product is an unbiased estimator of the target. scikit-agent calls this
+the "all-in-one" operator. The two draws enter the training grid under a
+two-copy naming convention: a shock `psi` appears as `psi_0` and `psi_1`, and
+`shock_copies=2` requests them.
+
+## Two Residual Losses
+
+scikit-agent ships two losses built on this operator. They differ in which
+optimality condition the residual $f$ encodes.
+
+### The Euler Loss
+
+{py:class}`~skagent.loss.EulerEquationLoss` encodes the first-order condition.
+For a consumption-saving model it equates the marginal utility of consuming
+today with the discounted expected marginal utility of consuming tomorrow.
+Writing $u$ for the utility function, $c_t$ for consumption in period $t$,
+$\beta$ for the discount factor (read from the model's discount variable), and
+$R$ for the gross return on savings, the residual is
+
+$$
+f = u'(c_t) - \beta\, \mathbb{E}_t\!\left[\,R\, u'(c_{t+1})\,\right],
+$$
+
+which is zero at the optimum. A first-order condition constrains the _slope_ of
+the policy, how the control responds to the state, but leaves its overall
+_level_ unpinned. Training on the Euler residual alone can therefore learn a
+policy of the right shape sitting at the wrong height. The loss needs only a
+decision rule, so it pairs with a policy-only network,
+{py:class}`~skagent.ann.BlockPolicyNet`.
+
+### The Bellman Loss
+
+{py:class}`~skagent.loss.BellmanEquationLoss` encodes the Bellman equation
+itself. Writing $V$ for the value function, $s$ for the current state, and $s'$
+for next period's state, the residual is
+
+$$
+f = V(s) - \left[\,u(s, c) + \beta\, V(s')\,\right],
+$$
+
+the gap between the value a state is assigned and the reward-plus-continuation
+it actually delivers. Because it references $V$ directly, this loss anchors the
+policy's level as well as its slope, curing the level ambiguity that the Euler
+residual leaves behind. It requires an explicit value function, so it pairs with
+{py:class}`~skagent.ann.BlockPolicyValueNet`, a shared-backbone network carrying
+a policy head and a value head that one optimizer trains together.
+
+### Choosing Between Them
+
+| Property                  | Euler loss          | Bellman loss          |
+| ------------------------- | ------------------- | --------------------- |
+| Optimality condition      | first-order (Euler) | Bellman equation      |
+| Requires a value function | no                  | yes                   |
+| Pairs with                | `BlockPolicyNet`    | `BlockPolicyValueNet` |
+| Identifies                | slope only          | slope and level       |
+
+Reach for the Euler loss when it is lighter to set up and the policy's level is
+pinned some other way; reach for the Bellman loss when the level itself must be
+correct, as when validating a trained policy against a known closed-form
+solution.
+
+## Running the Training Loop
+
+{py:func}`~skagent.algos.maliar.maliar_training_loop` runs the full outer loop.
+It builds a {py:class}`~skagent.ann.BlockPolicyNet`, alternates a batch of
+stochastic-gradient updates with a forward-simulation step that redraws the
+training states from the model's own ergodic set, and stops once the parameters
+settle or a maximum iteration count is reached.
+
+```python
+import skagent.algos.maliar as maliar
+import skagent.loss as loss
+
+euler_loss = loss.EulerEquationLoss(bp, parameters=calibration, constrained=True)
+
+policy, states = maliar.maliar_training_loop(
+    bp,
+    euler_loss,
+    states_0,
+    calibration,
+    shock_copies=2,  # independent draws for the all-in-one operator
+    max_iterations=40,
+    tolerance=1e-6,
+    network_width=32,
+)
+```
+
+The resampling step earns its place: a network trained only on the initial grid
+learns the policy where the grid happens to sit, not where the model actually
+spends its time. The loop returns the trained policy network and the final panel
+of training states.
+
+Because {py:func}`~skagent.algos.maliar.maliar_training_loop` builds a
+policy-only network internally, it pairs naturally with the Euler loss. To train
+with a value head instead, build a {py:class}`~skagent.ann.BlockPolicyValueNet`
+and drive it with {py:func}`~skagent.ann.train_block_nn` and
+{py:class}`~skagent.loss.BellmanEquationLoss` directly, resampling the states
+between batches yourself. The known-solution example below does exactly this.
+
+## Constrained Controls
+
+When a control is bounded and the constraint can bind, pass `constrained=True`
+to {py:class}`~skagent.loss.EulerEquationLoss`, as above. The loss then encodes
+the complementarity condition that holds at the bound through a smooth
+Fischer-Burmeister residual. The mechanics, and how the loss-side condition
+composes with feasibility built into the network's output layer, are covered in
+{doc}`constraints`.
+
+## Worked Examples
+
+Two runnable examples in the gallery carry these pieces end to end:
+
+- {doc}`../auto_examples/algorithms/plot_maliar_training_loop` trains the Euler
+  loop on U-3, Carroll's buffer-stock consumption-saving model, which has no
+  closed form, and checks the learned consumption function against buffer-stock
+  invariants.
+- {doc}`../auto_examples/algorithms/plot_train_against_known_solution` trains
+  the Bellman loss with a value head on U-2, a permanent-income model whose
+  policy is known in closed form, and reports a mean relative error near one
+  percent.
+
+For the class and function reference, see {doc}`../api/algorithms` and
+{doc}`../api/loss`.

--- a/docs/user_guide/maliar.md
+++ b/docs/user_guide/maliar.md
@@ -3,7 +3,7 @@
 Many dynamic programs have no closed-form solution, and discretizing the state
 space scales badly as states accumulate. The Maliar method (Maliar, Maliar, and
 Winant 2021) sidesteps both problems: it represents the decision rule as a
-neural network and turns the search for a policy into the minimization of an
+neural network and turns the search for a policy into minimizing an
 equation-residual loss over a sample of states. This page explains what the
 method minimizes, the two residual losses scikit-agent provides, and how to run
 the training loop.
@@ -21,8 +21,8 @@ policy for suppressing the residual's sampling noise rather than for satisfying
 the condition in expectation, and that extra variance term distorts the solution
 of any stochastic model. The Maliar method instead draws two independent shock
 realizations, evaluates the residual at each while holding the current control
-fixed, and multiplies the two. Writing $f_a$ and $f_b$ for the residuals at the
-two draws, independence gives
+fixed, and multiplies the two. Call these residuals $f_a$ and $f_b$; because the
+draws are independent,
 
 $$
 \mathbb{E}[f_a\, f_b] = \mathbb{E}[f_a]\,\mathbb{E}[f_b] = (\mathbb{E}[f])^2,
@@ -35,17 +35,17 @@ two-copy naming convention: a shock `psi` appears as `psi_0` and `psi_1`, and
 
 ## Two Residual Losses
 
-scikit-agent ships two losses built on this operator. They differ in which
+scikit-agent provides two losses built on this operator. They differ in which
 optimality condition the residual $f$ encodes.
 
 ### The Euler Loss
 
-{py:class}`~skagent.loss.EulerEquationLoss` encodes the first-order condition.
-For a consumption-saving model it equates the marginal utility of consuming
-today with the discounted expected marginal utility of consuming tomorrow.
-Writing $u$ for the utility function, $c_t$ for consumption in period $t$,
-$\beta$ for the discount factor (read from the model's discount variable), and
-$R$ for the gross return on savings, the residual is
+The Euler loss, {py:class}`~skagent.loss.EulerEquationLoss`, encodes the
+first-order condition. For a consumption-saving model it equates the marginal
+utility of consuming today with the discounted expected marginal utility of
+consuming tomorrow. Let $u$ be the utility function, $c_t$ consumption in period
+$t$, $\beta$ the discount factor (read from the model's discount variable), and
+$R$ the gross return on savings. The residual is
 
 $$
 f = u'(c_t) - \beta\, \mathbb{E}_t\!\left[\,R\, u'(c_{t+1})\,\right],
@@ -60,9 +60,9 @@ decision rule, so it pairs with a policy-only network,
 
 ### The Bellman Loss
 
-{py:class}`~skagent.loss.BellmanEquationLoss` encodes the Bellman equation
-itself. Writing $V$ for the value function, $s$ for the current state, and $s'$
-for next period's state, the residual is
+The Bellman loss, {py:class}`~skagent.loss.BellmanEquationLoss`, encodes the
+Bellman equation itself. Let $V$ be the value function, $s$ the current state,
+and $s'$ next period's state. The residual is
 
 $$
 f = V(s) - \left[\,u(s, c) + \beta\, V(s')\,\right],
@@ -91,11 +91,11 @@ solution.
 
 ## Running the Training Loop
 
-{py:func}`~skagent.algos.maliar.maliar_training_loop` runs the full outer loop.
-It builds a {py:class}`~skagent.ann.BlockPolicyNet`, alternates a batch of
-stochastic-gradient updates with a forward-simulation step that redraws the
-training states from the model's own ergodic set, and stops once the parameters
-settle or a maximum iteration count is reached.
+One call to {py:func}`~skagent.algos.maliar.maliar_training_loop` runs the full
+outer loop. It builds a {py:class}`~skagent.ann.BlockPolicyNet`, alternates a
+batch of stochastic-gradient updates with a forward-simulation step that redraws
+the training states from the model's own ergodic set, and stops once the
+parameters settle or a maximum iteration count is reached.
 
 ```python
 import skagent.algos.maliar as maliar
@@ -115,10 +115,10 @@ policy, states = maliar.maliar_training_loop(
 )
 ```
 
-The resampling step earns its place: a network trained only on the initial grid
-learns the policy where the grid happens to sit, not where the model actually
-spends its time. The loop returns the trained policy network and the final panel
-of training states.
+Resampling is what makes this more than gradient descent on a fixed grid:
+trained only on the initial grid, the network would learn the policy where the
+grid happens to sit, not where the model actually spends its time. The loop
+returns the trained policy network and the final panel of training states.
 
 Because {py:func}`~skagent.algos.maliar.maliar_training_loop` builds a
 policy-only network internally, it pairs naturally with the Euler loss. To train
@@ -132,9 +132,9 @@ between batches yourself. The known-solution example below does exactly this.
 When a control is bounded and the constraint can bind, pass `constrained=True`
 to {py:class}`~skagent.loss.EulerEquationLoss`, as above. The loss then encodes
 the complementarity condition that holds at the bound through a smooth
-Fischer-Burmeister residual. The mechanics, and how the loss-side condition
-composes with feasibility built into the network's output layer, are covered in
-{doc}`constraints`.
+Fischer-Burmeister residual. The {doc}`constraints` page covers the mechanics,
+and how the loss-side condition composes with feasibility built into the
+network's output layer.
 
 ## Worked Examples
 

--- a/src/skagent/ann.py
+++ b/src/skagent/ann.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from skagent.block import normalize_bound
 from skagent.grid import Grid
 import torch
 from skagent.utils import create_vectorized_function_wrapper_with_mapping
@@ -57,21 +58,17 @@ class BellmanPeriodMixin:
         self.iset = list(self.cobj.iset)
 
     def _setup_bound(self, bound_func, bound_name):
-        """Set up a vectorized bound function from a callable or None.
+        """Set up a vectorized bound function from a callable, number, or None.
 
-        Numeric bounds (e.g. ``lower_bound=0.0``) must be supplied as
-        zero-argument callables (e.g. ``lambda: 0.0``); a plain numeric value
-        is rejected so it cannot silently disable the bound through a
-        truthiness check.
+        The bound is normalized with :func:`skagent.block.normalize_bound`: a
+        number becomes a zero-argument callable, a callable is used as-is, and
+        ``None`` disables the bound on that side. ``Control`` already
+        normalizes its bounds at construction, so this is normally a no-op;
+        it also covers bounds set directly on the control object.
         """
+        bound_func = normalize_bound(bound_func, bound_name)
         if bound_func is None:
             return None, None
-        if not callable(bound_func):
-            raise TypeError(
-                f"{bound_name} must be a callable or None; got "
-                f"{type(bound_func).__name__}. Wrap numeric constants in a "
-                f"zero-argument callable, e.g. `lambda: {bound_func}`."
-            )
         sig = inspect.signature(bound_func)
         param_names = list(sig.parameters.keys())
         param_to_column = {}

--- a/src/skagent/block.py
+++ b/src/skagent/block.py
@@ -31,6 +31,50 @@ class Aggregate:
         self.dist = dist
 
 
+def normalize_bound(bound, bound_name="bound"):
+    """Normalize a control bound to a callable or ``None``.
+
+    A bound may be declared as:
+
+    - ``None`` -- the control is unbounded on that side;
+    - a number (``int`` or ``float``) -- a constant bound, wrapped into a
+      zero-argument callable so every consumer sees a uniform callable
+      interface;
+    - a callable -- an 'equation function' whose parameter names are drawn
+      from the control's information set.
+
+    Booleans are rejected so that ``upper_bound=True`` is not silently read
+    as the numeric bound ``1.0``.
+
+    Parameters
+    ----------
+    bound : None, int, float, or callable
+        The bound as declared on a :class:`Control`.
+    bound_name : str
+        Name used in error messages (e.g. ``"lower_bound"``).
+
+    Returns
+    -------
+    callable or None
+        ``None`` if the bound is absent, otherwise a callable.
+    """
+    if bound is None:
+        return None
+    if isinstance(bound, bool):
+        raise TypeError(
+            f"{bound_name} must be None, a number, or a callable; got bool {bound!r}."
+        )
+    if isinstance(bound, (int, float)):
+        value = float(bound)
+        return lambda: value
+    if callable(bound):
+        return bound
+    raise TypeError(
+        f"{bound_name} must be None, a number, or a callable; got "
+        f"{type(bound).__name__}."
+    )
+
+
 class Control:
     """
     Used to designate a variable that is a control variable.
@@ -40,11 +84,15 @@ class Control:
     iset : list of str
         The labels of the variables that are in the information set of this control.
 
-    lower_bound : function
-        An 'equation function' which evaluates to the lower bound of the control variable.
+    lower_bound : number, callable, or None
+        The lower bound of the control variable. A number is treated as a
+        constant bound; a callable is an 'equation function' whose parameter
+        names are variables in ``iset``. ``None`` leaves the control unbounded
+        below.
 
-    upper_bound : function
-        An 'equation function' which evaluates to the upper bound of the control variable.
+    upper_bound : number, callable, or None
+        The upper bound of the control variable, declared the same way as
+        ``lower_bound``. ``None`` leaves the control unbounded above.
 
     agent : str
         A label identifying the agent role to which this control is attributed.
@@ -52,8 +100,8 @@ class Control:
 
     def __init__(self, iset, lower_bound=None, upper_bound=None, agent=None):
         self.iset = iset
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+        self.lower_bound = normalize_bound(lower_bound, "lower_bound")
+        self.upper_bound = normalize_bound(upper_bound, "upper_bound")
         self.agent = agent
 
 

--- a/src/skagent/loss.py
+++ b/src/skagent/loss.py
@@ -391,6 +391,44 @@ class BellmanEquationLoss(_EquationLossBase):
         return loss
 
 
+def _complementarity_residual(f, slack_lower, slack_upper):
+    r"""Smooth complementarity residual for a control's Euler residual ``f``.
+
+    Combines whichever bounds are present using the sign convention that the
+    residual ``f`` is :math:`\geq 0` when an upper bound binds and
+    :math:`\leq 0` when a lower bound binds:
+
+    - upper only: :math:`\text{FB}(f, s_u)`
+    - lower only: :math:`\text{FB}(-f, s_l)`
+    - both: :math:`\text{FB}(s_u, -\text{FB}(s_l, -f))`, a two-sided form that
+      reduces to either one-sided residual when the opposite bound is slack
+      (so a control with a non-binding floor and a binding ceiling matches the
+      upper-only residual, leaving upper-bound benchmarks unchanged).
+
+    Parameters
+    ----------
+    f : torch.Tensor
+        The Euler equation residual for one control.
+    slack_lower, slack_upper : torch.Tensor or None
+        Lower slack ``x - lb`` and upper slack ``ub - x``; ``None`` when the
+        corresponding bound is absent.
+
+    Returns
+    -------
+    torch.Tensor or None
+        The complementarity residual, or ``None`` when the control has neither
+        bound (the caller then uses the one-sided relu fallback).
+    """
+    if slack_upper is not None and slack_lower is not None:
+        inner = fischer_burmeister(slack_lower, -f)
+        return fischer_burmeister(slack_upper, -inner)
+    if slack_upper is not None:
+        return fischer_burmeister(f, slack_upper)
+    if slack_lower is not None:
+        return fischer_burmeister(-f, slack_lower)
+    return None
+
+
 class EulerEquationLoss(_EquationLossBase):
     """
     Creates an Euler equation loss function for the Maliar method.
@@ -420,31 +458,26 @@ class EulerEquationLoss(_EquationLossBase):
 
     **Handling Inequality Constraints (Fischer-Burmeister):**
 
-    When ``constrained=True`` and a control has an ``upper_bound`` defined on its
-    ``Control`` object, the complementarity conditions
+    When ``constrained=True``, a control's declared bounds are turned into a
+    smooth complementarity residual via the Fischer-Burmeister function
+    (Maliar et al. 2021, equation 25), :math:`\\text{FB}(a, b) = a + b -
+    \\sqrt{a^2 + b^2 + \\varepsilon}`, which is zero (up to the regularizer
+    :math:`\\sqrt{\\varepsilon}`) exactly where :math:`a \\geq 0`,
+    :math:`b \\geq 0`, :math:`a \\cdot b = 0`.
 
-    .. math::
+    The sign convention is that the Euler residual :math:`f` is :math:`\\geq 0`
+    when an upper bound binds and :math:`\\leq 0` when a lower bound binds.
+    Writing :math:`s_u = \\overline{x} - x` and :math:`s_l = x - \\underline{x}`
+    for the upper and lower slacks, the per-control residual is
 
-        f \\geq 0, \\quad s \\geq 0, \\quad f \\cdot s = 0
-
-    (where :math:`s` is the constraint slack) are replaced by the smooth
-    Fischer-Burmeister equation (Maliar et al. 2021, equation 25):
-
-    .. math::
-
-        \\text{FB}(f, s) = f + s - \\sqrt{f^2 + s^2} = 0
-
-    For controls without an explicit ``upper_bound``, the loss falls back to the
-    one-sided :math:`\\text{relu}(-f)^2` formulation.
-
-    **Scope: upper bounds only.**
-    The constrained mode currently models the upper-bound side of the
-    complementarity condition: :math:`f \\geq 0`, :math:`s = ub - c \\geq
-    0`, :math:`f \\cdot s = 0`. Although ``Control`` accepts both
-    ``lower_bound`` and ``upper_bound``, lower-bound constraints are not
-    yet handled here; bilateral support requires also flipping the
-    residual sign for lower-binding cases (``FB(-f, c - lb)``) and is
-    left as a follow-up.
+    - upper bound only: :math:`\\text{FB}(f, s_u)`;
+    - lower bound only: :math:`\\text{FB}(-f, s_l)`;
+    - both bounds: :math:`\\text{FB}(s_u, -\\text{FB}(s_l, -f))`, a two-sided
+      form that reduces to either one-sided residual when the opposite bound is
+      slack, so a control with a non-binding floor and a binding ceiling matches
+      the upper-only residual;
+    - no bound: the one-sided fallback :math:`\\text{relu}(-f)`, penalizing only
+      violations of :math:`f \\geq 0`.
 
     Parameters
     ----------
@@ -481,23 +514,30 @@ class EulerEquationLoss(_EquationLossBase):
             raise ValueError(f"weight must be > 0, got {weight}")
         self.weight = weight
         self.constrained = constrained
-        # Cache upper_bound parameter names so _compute_slack does not call
+        # Cache bound parameter names so the slack helpers do not call
         # inspect.signature on every forward pass.
         self._upper_bound_params: dict[str, list[str]] = {}
+        self._lower_bound_params: dict[str, list[str]] = {}
         if self.constrained:
             for sym, rule in bellman_period.block.dynamics.items():
                 if not hasattr(rule, "iset"):
                     continue
                 ub = getattr(rule, "upper_bound", None)
-                if ub is None:
-                    continue
-                self._upper_bound_params[sym] = list(inspect.signature(ub).parameters)
-            if not self._upper_bound_params:
+                if ub is not None:
+                    self._upper_bound_params[sym] = list(
+                        inspect.signature(ub).parameters
+                    )
+                lb = getattr(rule, "lower_bound", None)
+                if lb is not None:
+                    self._lower_bound_params[sym] = list(
+                        inspect.signature(lb).parameters
+                    )
+            if not self._upper_bound_params and not self._lower_bound_params:
                 logger.warning(
-                    "constrained=True but no Control in the block has an upper_bound. "
-                    "The one-sided loss will use relu(-f)^2 as a fallback. "
-                    "Define upper_bound on Control objects to enable the "
-                    "Fischer-Burmeister formulation."
+                    "constrained=True but no Control in the block has a "
+                    "lower_bound or upper_bound. The one-sided loss will use "
+                    "relu(-f)^2 as a fallback. Define a bound on Control "
+                    "objects to enable the Fischer-Burmeister formulation."
                 )
 
     def _compute_slack(
@@ -522,6 +562,28 @@ class EulerEquationLoss(_EquationLossBase):
         ub_value = control_obj.upper_bound(**ub_args)
 
         return ub_value - controls_t[control_sym]
+
+    def _compute_lower_slack(
+        self, control_sym: str, controls_t: dict, states_t: dict, shocks_t: dict
+    ) -> torch.Tensor | None:
+        """Compute lower-bound slack ``control_value - lower_bound``.
+
+        Returns ``None`` if the control has no lower bound defined. Mirrors
+        :meth:`_compute_slack` (the upper-bound side); together they supply the
+        two slacks of the bilateral complementarity condition.
+        """
+        param_names = self._lower_bound_params.get(control_sym)
+        if param_names is None:
+            return None
+
+        control_obj = self.bellman_period.block.dynamics[control_sym]
+        pre_state = self.bellman_period.compute_pre_state(
+            control_sym, states_t, shocks=shocks_t, parameters=self.parameters
+        )
+        lb_args = {k: pre_state[k] for k in param_names if k in pre_state}
+        lb_value = control_obj.lower_bound(**lb_args)
+
+        return controls_t[control_sym] - lb_value
 
     def _aio_residual_pair(self, df: Callable, states_t: dict, shocks: dict):
         """Two Euler residuals sharing the current control, at two independent
@@ -614,15 +676,25 @@ class EulerEquationLoss(_EquationLossBase):
         if self.constrained:
             total = 0.0
             for ctrl_sym in res_a:
-                slack = self._compute_slack(ctrl_sym, controls_t, states_t, shocks_t)
-                if slack is not None:
-                    total = total + fischer_burmeister(
-                        res_a[ctrl_sym], slack
-                    ) * fischer_burmeister(res_b[ctrl_sym], slack)
-                else:
+                slack_upper = self._compute_slack(
+                    ctrl_sym, controls_t, states_t, shocks_t
+                )
+                slack_lower = self._compute_lower_slack(
+                    ctrl_sym, controls_t, states_t, shocks_t
+                )
+                rho_a = _complementarity_residual(
+                    res_a[ctrl_sym], slack_lower, slack_upper
+                )
+                if rho_a is None:
+                    # No bound on this control: one-sided penalty on f >= 0.
                     total = total + torch.relu(-res_a[ctrl_sym]) * torch.relu(
                         -res_b[ctrl_sym]
                     )
+                else:
+                    rho_b = _complementarity_residual(
+                        res_b[ctrl_sym], slack_lower, slack_upper
+                    )
+                    total = total + rho_a * rho_b
             return self.weight * total
 
         # Unconstrained loss: mean of the product estimates (E[f])**2.

--- a/tests/test_ann.py
+++ b/tests/test_ann.py
@@ -21,6 +21,8 @@ import skagent.models.perfect_foresight as pfm
 import torch
 import unittest
 
+from skagent.block import Control, DBlock
+
 # Deterministic test seed - change this single value to modify all seeding
 # Using same seed as test_maliar.py for consistency across test suite
 TEST_SEED = 10077693
@@ -270,6 +272,46 @@ class test_ann_lr(unittest.TestCase):
 
         self.assertTrue(
             torch.allclose(c_ann.flatten(), given_0_N["a"].flatten(), atol=0.03)
+        )
+
+    def test_numeric_bounds_match_callable_bounds(self):
+        """Raw-number bounds build a policy network identical to one declared
+        with equivalent zero-argument callables, and both respect the open
+        bounds. Would fail if the numeric-bound path were dropped or scaled
+        differently from the callable path."""
+
+        def _block(lb, ub):
+            return DBlock(
+                **{
+                    "name": "numeric-vs-callable bounds",
+                    "shocks": {},
+                    "dynamics": {
+                        "c": Control(["a"], lower_bound=lb, upper_bound=ub),
+                        "a2": lambda a, c: a - c,
+                        "u": lambda c: c,
+                    },
+                    "reward": {"u": "consumer"},
+                }
+            )
+
+        cal = {"beta": 0.9}
+        bp_num = bellman.BellmanPeriod(_block(0.0, 1.0), "beta", cal)
+        bp_cb = bellman.BellmanPeriod(_block(lambda: 0.0, lambda: 1.0), "beta", cal)
+
+        net_num = ann.BlockPolicyNet(bp_num, width=8, init_seed=TEST_SEED)
+        net_cb = ann.BlockPolicyNet(bp_cb, width=8, init_seed=TEST_SEED)
+
+        states = {"a": torch.linspace(0.1, 2.0, 16, device=device)}
+        c_num = net_num.decision_function(states, {}, {})["c"]
+        c_cb = net_cb.decision_function(states, {}, {})["c"]
+
+        self.assertTrue(
+            torch.allclose(c_num, c_cb),
+            "numeric and callable bound declarations gave different policies",
+        )
+        self.assertTrue(
+            bool((c_num > 0.0).all()) and bool((c_num < 1.0).all()),
+            f"numeric-bounded policy escaped the open interval (0, 1): {c_num}",
         )
 
     def test_case_9_empty_information_set(self):

--- a/tests/test_maliar.py
+++ b/tests/test_maliar.py
@@ -16,9 +16,10 @@ from skagent.models.benchmarks import (
     get_benchmark_calibration,
     get_analytical_policy,
     get_reference_policy,
+    crra_utility,
 )
 from skagent.simulation.monte_carlo import draw_shocks
-from skagent.utils import reconcile
+from skagent.utils import reconcile, fischer_burmeister
 from test_benchmarks import assert_consumption_policy_diagnostics
 
 # Deterministic test seed - change this single value to modify all seeding
@@ -185,9 +186,9 @@ class TestBellmanLossFunctions(unittest.TestCase):
                     upper_bound=lambda wealth: wealth,
                     agent="consumer",
                 ),
-                "wealth": lambda wealth, income, consumption: wealth
-                + income
-                - consumption,
+                "wealth": lambda wealth, income, consumption: (
+                    wealth + income - consumption
+                ),
                 "utility": lambda consumption: torch.log(
                     consumption + 1e-8
                 ),  # Add small constant to avoid log(0)
@@ -1217,6 +1218,133 @@ class TestD4ConstrainedEulerVFI(unittest.TestCase):
             0.02,
             f"Euler+FB pointwise gap to VFI should stay tight even at the "
             f"constraint kink. Got max relative error: {max_rel_error:.4%}",
+        )
+
+
+class TestBilateralFischerBurmeister(unittest.TestCase):
+    """EulerEquationLoss(constrained=True) models the lower-bound side of the
+    complementarity condition, not only the upper-bound side.
+
+    Addresses the PR #223 review: a ``lower_bound`` declared on a ``Control``
+    must enter the Fischer-Burmeister residual as ``FB(-f, x - lb)``, and a
+    control with both bounds must reduce to the existing upper-bound residual
+    when the lower bound is slack (so upper-bound benchmarks like D-4 are
+    unaffected). These are deterministic models, so the all-in-one product of
+    two draws collapses to the square of a single complementarity residual.
+    """
+
+    def _det_crra_block(self, lower_bound=None, upper_bound=None):
+        return model.DBlock(
+            **{
+                "name": "bilateral_fb_test",
+                "shocks": {},
+                "dynamics": {
+                    "m": lambda a, R, y: a * R + y,
+                    "c": model.Control(
+                        ["m"],
+                        lower_bound=lower_bound,
+                        upper_bound=upper_bound,
+                        agent="consumer",
+                    ),
+                    "a": lambda m, c: m - c,
+                    "u": lambda c, CRRA: crra_utility(c, CRRA),
+                },
+                "reward": {"u": "consumer"},
+            }
+        )
+
+    def test_lower_bound_enters_complementarity_residual(self):
+        torch.manual_seed(TEST_SEED)
+        cal = {"DiscFac": 0.92, "R": 1.04, "y": 1.0, "CRRA": 2.0}
+        R, y = cal["R"], cal["y"]
+
+        # Lower bound only: c >= 0.5 m. The policy is pinned to the bound, so the
+        # lower bound binds (slack c - 0.5 m = 0) at every state.
+        block = self._det_crra_block(lower_bound=lambda m: 0.5 * m)
+        block.construct_shocks(cal)
+        bp = bellman.BellmanPeriod(block, "DiscFac", cal)
+
+        def df_at_lower_bound(states_t, shocks_t, parameters):
+            m = R * states_t["a"] + y
+            return {"c": 0.5 * m}
+
+        a_test = torch.linspace(0.5, 4.0, 16)
+        states = {"a": a_test}
+        input_grid = grid.Grid.from_dict({"a": a_test})
+
+        loss_fn = loss.EulerEquationLoss(bp, parameters=cal, constrained=True)
+        actual = loss_fn(df_at_lower_bound, input_grid)
+
+        # Expected: FB(-f, slack) squared, with slack = c - lb = 0.
+        f = euler_residual_of(bp, df_at_lower_bound, states, {}, cal)
+        slack_lower = torch.zeros_like(f)
+        expected = fischer_burmeister(-f, slack_lower) ** 2
+
+        self.assertTrue(
+            torch.allclose(actual, expected, atol=1e-6),
+            f"binding lower bound should give FB(-f, c-lb)^2; got {actual} "
+            f"vs expected {expected}",
+        )
+        # Regression guard: must NOT collapse to the upper-only relu fallback.
+        relu_fallback = torch.relu(-f) ** 2
+        self.assertFalse(
+            torch.allclose(actual, relu_fallback, atol=1e-6),
+            "lower-bound loss collapsed to relu(-f)^2; bilateral FB not applied",
+        )
+
+    def test_complementarity_residual_reductions_and_kkt_zeros(self):
+        """The combiner reduces exactly to the one-sided residuals and is
+        exactly zero at every KKT point of a box-constrained control.
+
+        These exact properties (not pointwise equality away from optimum) are
+        what guarantee the two-sided form leaves upper-bound benchmarks like
+        D-4 converging to the same policy.
+        """
+        f = torch.linspace(-2.0, 2.0, 9)
+        s = torch.full_like(f, 0.5)
+
+        # One-sided cases match the bare Fischer-Burmeister residual exactly.
+        self.assertTrue(
+            torch.allclose(
+                loss._complementarity_residual(f, None, s),
+                fischer_burmeister(f, s),
+            ),
+            "upper-only combiner must equal FB(f, s_u)",
+        )
+        self.assertTrue(
+            torch.allclose(
+                loss._complementarity_residual(f, s, None),
+                fischer_burmeister(-f, s),
+            ),
+            "lower-only combiner must equal FB(-f, s_l)",
+        )
+        # No bound -> None (caller uses the relu fallback).
+        self.assertIsNone(loss._complementarity_residual(f, None, None))
+
+        # Two-sided KKT zeros (exact to the FB regularization eps).
+        zero = torch.zeros(5)
+        big = torch.full((5,), 7.0)
+        f_pos = torch.linspace(0.1, 3.0, 5)  # f >= 0
+        # Upper binds: s_u = 0, f >= 0, lower slack -> residual 0.
+        self.assertTrue(
+            torch.allclose(
+                loss._complementarity_residual(f_pos, big, zero), zero, atol=1e-5
+            ),
+            "two-sided residual must vanish when the upper bound binds (f>=0)",
+        )
+        # Lower binds: s_l = 0, f <= 0, upper slack -> residual 0.
+        self.assertTrue(
+            torch.allclose(
+                loss._complementarity_residual(-f_pos, zero, big), zero, atol=1e-5
+            ),
+            "two-sided residual must vanish when the lower bound binds (f<=0)",
+        )
+        # Interior: f = 0, both slacks positive -> residual 0.
+        self.assertTrue(
+            torch.allclose(
+                loss._complementarity_residual(zero, big, big), zero, atol=1e-5
+            ),
+            "two-sided residual must vanish at an interior optimum (f=0)",
         )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,6 +51,44 @@ class test_Control(unittest.TestCase):
     def test_attributes(self):
         self.assertEqual(self.test_control_A.agent, "myagent")
 
+    def test_numeric_bounds_become_constant_callables(self):
+        """A raw number bound is normalized to a zero-argument callable so
+        every consumer sees a uniform callable interface."""
+        c = model.Control(["m"], lower_bound=1e-3, upper_bound=2)
+        self.assertTrue(callable(c.lower_bound))
+        self.assertTrue(callable(c.upper_bound))
+        self.assertAlmostEqual(c.lower_bound(), 1e-3)
+        # An int upper bound is coerced to float.
+        self.assertEqual(c.upper_bound(), 2.0)
+        self.assertIsInstance(c.upper_bound(), float)
+
+    def test_callable_bounds_pass_through_unchanged(self):
+        """A callable bound is stored as-is, not re-wrapped."""
+        ub = lambda m: m  # noqa: E731
+        c = model.Control(["m"], upper_bound=ub)
+        self.assertIs(c.upper_bound, ub)
+
+    def test_omitted_bounds_are_none(self):
+        c = model.Control(["m"])
+        self.assertIsNone(c.lower_bound)
+        self.assertIsNone(c.upper_bound)
+
+    def test_bool_bound_rejected(self):
+        """``True`` must not be silently read as the numeric bound ``1.0``."""
+        with self.assertRaises(TypeError):
+            model.Control(["m"], upper_bound=True)
+
+    def test_non_numeric_non_callable_bound_rejected(self):
+        with self.assertRaises(TypeError):
+            model.Control(["m"], lower_bound="zero")
+
+    def test_normalize_bound_helper(self):
+        self.assertIsNone(model.normalize_bound(None))
+        f = model.normalize_bound(0.5)
+        self.assertEqual(f(), 0.5)
+        g = lambda a: a  # noqa: E731
+        self.assertIs(model.normalize_bound(g), g)
+
 
 class test_DBlock(unittest.TestCase):
     def setUp(self):

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -16,7 +16,7 @@ test_block_data = {
     # },
     "dynamics": {
         "m": lambda a, q: a * q,
-        "c": Control(["m"], upper_bound="a"),
+        "c": Control(["m"]),
         "a": lambda m, c, e: m * (1 - sf(c)) + e,
         #'e' : lambda e : e,
         "u": lambda c, CRRA: c ** (1 - CRRA) / (1 - CRRA),


### PR DESCRIPTION
## Summary

Adds bilateral inequality-constraint support to the Euler loss and a user guide for the Maliar method. Closes #215.

## Constraints

- `Control` accepts numeric bounds directly. A number becomes a zero-argument callable at the `Control` boundary through `normalize_bound`, and a boolean raises a `TypeError` so `upper_bound=True` cannot slip through as `1.0`. Existing callable bounds are unchanged.
- `EulerEquationLoss(constrained=True)` now covers both bounds with a bilateral Fischer-Burmeister residual, `FB(s_u, -FB(s_l, -f))`. When one bound is slack the residual collapses to the one-sided form, so a model with only an upper bound behaves exactly as before.
- The constraints user guide is rewritten for the bilateral loss and the numeric-bound API, with a table showing where each mechanism (network transform, complementarity loss, VBI box constraints) applies.

## Maliar method user guide

- New `docs/user_guide/maliar.md` explains the all-in-one expectation operator (why multiplying two independent residual draws yields the unbiased estimator), the Euler and Bellman losses and how they differ on slope-versus-level identification, `maliar_training_loop`, and the link to constrained controls.
- The Algorithms guide links to the new page. A leftover duplicate "Solving a block directly" heading there is retitled "Overview".

## Testing

- Test suite: 387 passed, 3 skipped (the slow RL-convergence tests).
- Docs build clean, with no broken cross-references.

Drafted with assistance from Claude Code (Opus 4.8).
