### PR TITLE
Fix D-2/D-3 benchmark borrowing constraint to match unconstrained oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,30 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Benchmark blocks `d2_block` and `d3_block` imposed a no-borrowing constraint
+  (`c <= m`, i.e. end-of-period assets `a' >= 0`) that contradicts their
+  unconstrained perfect-foresight closed-form policies, which borrow against
+  human wealth. The blocks now use the natural borrowing limit `c <= m + H`,
+  with `H = y / r` derived from each calibration as a module-level constant, so
+  each coded model matches the analytical policy it is validated against. The
+  mismatch was latent until a solver exercised the control bounds; single-step
+  and analytical-policy tests missed it because their test states (`a >= 0.5`)
+  never reach the borrowing region.
+
+### Added
+
+- `tests/test_benchmark_bound_consistency.py`: regression test asserting each
+  unconstrained closed-form benchmark's analytical policy is feasible under the
+  block's own control bounds on states that reach the borrowing region
+  (`a' < 0`).
+
 ### Changed
+
+- `GymEnv._bounds_at` treats a single-point feasible set (`lo == hi`, which the
+  natural borrowing limit produces at `m = -H`) as valid, returning that point;
+  it now raises only on a genuinely inverted bound (`hi < lo`).
 
 - `compute_gradients_for_tensors` returns a zero tensor (instead of `None`) for
   a variable with no computational path to the target, and raises `ValueError`

--- a/docs/user_guide/algorithms.md
+++ b/docs/user_guide/algorithms.md
@@ -108,7 +108,9 @@ bp = bellman.BellmanPeriod(block_d2, "DiscFac", calibration)
 ```
 
 In D-2 the agent arrives with assets `a`, cash-on-hand `m = R*a + y` is formed,
-and the single control `c` (consumption) is chosen subject to `c <= m`.
+and the single control `c` (consumption) is chosen subject to the natural
+borrowing limit `c <= m + H`, where `H = y/(R-1)` is human wealth (the agent may
+borrow against future income).
 
 ### 2. Build the grid of starting points
 

--- a/examples/models/plot_benchmark_models.py
+++ b/examples/models/plot_benchmark_models.py
@@ -58,6 +58,14 @@ fixed meaning throughout every model on this page:
 The normalized models (U-2, U-3) additionally use lowercase :math:`m, c, a`
 for ratios to permanent income :math:`P_t`.
 
+Because a perfect-foresight agent can borrow against future income, the
+deterministic models (D-2, D-3) are feasible up to total wealth,
+:math:`c_t \le m_t + H_t` (the natural borrowing limit :math:`A_t \ge -H_t`),
+not merely cash-on-hand. The limit tightens to :math:`c_t \le m_t` only when the
+worst-case future income is zero, i.e. with income uncertainty whose support
+reaches zero (U-3) or a borrowing constraint imposed by construction (D-4); that
+binding constraint is what forecloses a closed form.
+
 References
 ==========
 

--- a/src/skagent/env.py
+++ b/src/skagent/env.py
@@ -435,9 +435,12 @@ class GymEnv(gym.Env):
             if self.control.upper_bound is not None
             else self.default_upper
         )
-        if hi <= lo:
+        # lo == hi is a valid single-point feasible set (the natural borrowing
+        # limit collapses the choice to one action); only a truly inverted
+        # bound (hi < lo) is an error.
+        if hi < lo:
             raise ValueError(
-                f"Control {self.control_sym!r} has degenerate bounds at "
+                f"Control {self.control_sym!r} has inverted bounds at "
                 f"pre-state {pre}: lo={lo}, hi={hi}"
             )
         return lo, hi

--- a/src/skagent/env.py
+++ b/src/skagent/env.py
@@ -415,6 +415,9 @@ class GymEnv(gym.Env):
     # -- internal helpers -------------------------------------------------
 
     def _unscale_one(self, a_norm: float, lo: float, hi: float) -> float:
+        # At a degenerate feasible set (lo == hi, the natural borrowing limit
+        # m = -H) the 1e-12 floor keeps c strictly interior rather than exactly
+        # c = lo, which for CRRA utility would be a c = 0 singularity (-inf).
         span = max(hi - lo, 1e-12)
         eps = self.bound_clearance * span
         a = float(np.clip(a_norm, -1.0, 1.0))

--- a/src/skagent/models/benchmarks.py
+++ b/src/skagent/models/benchmarks.py
@@ -234,9 +234,9 @@ d2_calibration = {
     "y": 1.0,
     "description": "D-2: Infinite horizon CRRA perfect foresight",
 }
-# Human wealth H = y / r: PV of the constant future income, a fixed model
-# parameter (module header: W_t = m_t + H_t). The closed form borrows against
-# it, so the feasible upper bound is m + H (limit a' >= -H), not m.
+# Human wealth H = y / (R - 1): present value of the constant future income
+# stream (module header: W_t = m_t + H_t). The closed form borrows against it,
+# so the feasible upper bound is total wealth m + H, not cash-on-hand m.
 _D2_HUMAN_WEALTH = d2_calibration["y"] / _human_wealth_rate(d2_calibration["R"])
 
 d2_block = DBlock(
@@ -400,8 +400,8 @@ d3_calibration = {
     # Note: liv=1.0 is the initial STATE, not a parameter, so it's passed in initial_states
     "description": "D-3: Blanchard discrete-time mortality",
 }
-# Human wealth H = y / r (mortality scales the MPC, not H); the feasible upper
-# bound is total wealth m + H, matching _validate_d2_d3_solution's c < m + H.
+# Human wealth H = y / (R - 1) (mortality scales the MPC, not H); the feasible
+# upper bound is total wealth m + H, matching _validate_d2_d3_solution's c<m+H.
 _D3_HUMAN_WEALTH = d3_calibration["y"] / _human_wealth_rate(d3_calibration["R"])
 
 d3_block = DBlock(

--- a/src/skagent/models/benchmarks.py
+++ b/src/skagent/models/benchmarks.py
@@ -234,6 +234,10 @@ d2_calibration = {
     "y": 1.0,
     "description": "D-2: Infinite horizon CRRA perfect foresight",
 }
+# Human wealth H = y / r: PV of the constant future income, a fixed model
+# parameter (module header: W_t = m_t + H_t). The closed form borrows against
+# it, so the feasible upper bound is m + H (limit a' >= -H), not m.
+_D2_HUMAN_WEALTH = d2_calibration["y"] / _human_wealth_rate(d2_calibration["R"])
 
 d2_block = DBlock(
     **{
@@ -241,7 +245,9 @@ d2_block = DBlock(
         "shocks": {},
         "dynamics": {
             "m": lambda a, R, y: a * R + y,
-            "c": Control(["m"], upper_bound=lambda m: m, agent="consumer"),
+            "c": Control(
+                ["m"], upper_bound=lambda m: m + _D2_HUMAN_WEALTH, agent="consumer"
+            ),
             "a": lambda m, c: m - c,
             "u": lambda c, CRRA: crra_utility(c, CRRA),
         },
@@ -394,6 +400,9 @@ d3_calibration = {
     # Note: liv=1.0 is the initial STATE, not a parameter, so it's passed in initial_states
     "description": "D-3: Blanchard discrete-time mortality",
 }
+# Human wealth H = y / r (mortality scales the MPC, not H); the feasible upper
+# bound is total wealth m + H, matching _validate_d2_d3_solution's c < m + H.
+_D3_HUMAN_WEALTH = d3_calibration["y"] / _human_wealth_rate(d3_calibration["R"])
 
 d3_block = DBlock(
     **{
@@ -403,7 +412,9 @@ d3_block = DBlock(
         },
         "dynamics": {
             "m": lambda a, R, y: a * R + y,
-            "c": Control(["m"], upper_bound=lambda m: m, agent="consumer"),
+            "c": Control(
+                ["m"], upper_bound=lambda m: m + _D3_HUMAN_WEALTH, agent="consumer"
+            ),
             "a": lambda m, c: m - c,
             "liv": lambda liv, live: liv * live,  # liv becomes 0 if agent dies (live=0)
             "u": lambda c, liv, CRRA: liv

--- a/tests/test_benchmark_bound_consistency.py
+++ b/tests/test_benchmark_bound_consistency.py
@@ -1,0 +1,76 @@
+"""Regression test: a closed-form benchmark's block bounds must be consistent
+with its analytical policy, INCLUDING the borrowing region.
+
+The unconstrained perfect-foresight closed forms (D-2, D-3) borrow against
+human wealth, so at low wealth the optimal end-of-period assets are negative
+(``a' < 0``). The blocks previously imposed ``c <= m`` (equivalently
+``a' >= 0``), a no-borrowing constraint the closed forms violate there: block and
+oracle silently described different models. Single-step and analytical-policy
+tests missed it because their test states (``a >= 0.5``) never reach the
+borrowing region. This test evaluates each block's OWN control bounds through the
+framework and asserts the analytical policy is feasible under them, on states
+that do reach ``a' < 0``.
+"""
+
+from inspect import signature
+
+import torch
+
+from skagent.bellman import BellmanPeriod
+from skagent.models import benchmarks as bm
+
+# Unconstrained closed-form models whose oracle borrows against human wealth.
+# Grids start below the no-borrowing kink so the unconstrained optimum implies
+# a' < 0 for some rows (U-2 keeps a loose neural-solver cap and is not covered).
+BORROWING_MODELS = {
+    "D-2": torch.linspace(-0.15, 4.0, 25),
+    "D-3": torch.linspace(-0.15, 4.0, 25),
+}
+
+
+def _eval_bound(bound_fn, scope):
+    """Evaluate a Control bound the way the framework does: resolve its lambda's
+    named parameters from the model parameters merged with the pre-decision
+    state (a bound may reference either, e.g. the natural limit m + H)."""
+    if bound_fn is None:
+        return None
+    return bound_fn(*[scope[name] for name in signature(bound_fn).parameters])
+
+
+def test_block_bounds_consistent_with_analytical_policy():
+    for model_id, a in BORROWING_MODELS.items():
+        block = bm.get_benchmark_model(model_id)
+        cal = bm.get_benchmark_calibration(model_id)
+        policy = bm.get_analytical_policy(model_id)
+
+        states = {"a": a}
+        shocks = {}
+
+        bp = BellmanPeriod(block, "DiscFac", cal)
+        pre = bp.compute_pre_state("c", states, shocks=shocks, parameters=cal)
+        c = policy(states, shocks, cal)["c"]
+
+        ctrl = block.dynamics["c"]
+        scope = {**cal, **pre}
+        lower = _eval_bound(ctrl.lower_bound, scope)
+        upper = _eval_bound(ctrl.upper_bound, scope)
+
+        if lower is not None:
+            lower = torch.as_tensor(lower, dtype=c.dtype)
+            assert torch.all(c >= lower - 1e-9), (
+                f"{model_id}: analytical consumption falls below the block lower bound"
+            )
+        assert upper is not None, f"{model_id}: expected an upper bound on consumption"
+        upper = torch.as_tensor(upper, dtype=c.dtype)
+        assert torch.all(c <= upper + 1e-9), (
+            f"{model_id}: analytical consumption exceeds the block upper bound "
+            f"(borrowing-constraint mismatch: block says c <= {float(upper.min()):.3f}, "
+            f"oracle wants up to c = {float(c.max()):.3f})"
+        )
+
+        # Guard the guard: the states must actually reach the borrowing region,
+        # otherwise the old (buggy) c <= m bound would have passed this test too.
+        a_next = pre["m"] - c
+        assert torch.any(a_next < 0.0), (
+            f"{model_id}: test grid never reaches a' < 0; would not catch the bug"
+        )

--- a/tests/test_perfect_foresight.py
+++ b/tests/test_perfect_foresight.py
@@ -429,7 +429,7 @@ class TestPerfectForesightLifetimeReward(unittest.TestCase):
         Human wealth: H = y/r
         MPC bounds: 0 < κ < 1 (marginal propensity to consume)
         Feasibility: 0 < c < m + H (total wealth constraint)
-        Note: DBlock imposes c <= m, which may not hold for all parameter values
+        Note: the DBlock imposes the natural borrowing limit c <= m + H.
         """
         model_id = "D-3"
         calibration = get_benchmark_calibration(model_id)
@@ -493,7 +493,7 @@ class TestPerfectForesightLifetimeReward(unittest.TestCase):
         Human wealth: H = y/r
         MPC bounds: 0 < κ < 1 (marginal propensity to consume)
         Feasibility: 0 < c < m + H (total wealth constraint)
-        Note: DBlock imposes c <= m, which may not hold for all parameter values
+        Note: the DBlock imposes the natural borrowing limit c <= m + H.
         """
         model_id = "D-2"
         calibration = get_benchmark_calibration(model_id)

--- a/tests/test_sb3.py
+++ b/tests/test_sb3.py
@@ -133,10 +133,11 @@ def test_predict_unscaled_respects_per_state_bounds(d2_agent):
     d2_agent.learn(total_timesteps=64)
     obs = np.array([[1.0], [2.5], [5.0]], dtype=np.float32)
     c = d2_agent.predict_unscaled(obs)
-    # D-2: lo=0 (default), hi=m (Control.upper_bound).
+    # D-2 is unconstrained: lo=0 (default), hi=m+H (natural borrowing limit).
+    ub = d2_block.dynamics["c"].upper_bound(obs.reshape(-1))
     assert c.shape == (3,)
     assert np.all(c >= 0.0)
-    assert np.all(c <= obs.reshape(-1))
+    assert np.all(c <= ub)
 
 
 def test_decision_rule_drives_environment(d2_agent):
@@ -154,7 +155,8 @@ def test_decision_rule_drives_environment(d2_agent):
         state, action, reward, _, _, _ = env.step(dr)
         c = float(action["c"][0])
         m = float(state["a"][0]) * d2_calibration["R"] + d2_calibration["y"]
-        assert 0.0 <= c <= m  # respects D-2 borrowing constraint
+        ub = d2_block.dynamics["c"].upper_bound(m)  # m + H, natural borrowing limit
+        assert 0.0 <= c <= ub  # respects D-2 natural borrowing limit
         assert torch.is_tensor(reward["u"])
 
 
@@ -207,7 +209,8 @@ def test_snapshot_decision_rule_drives_environment(d2_agent):
         state, action, reward, _, _, _ = env.step(dr)
         c = float(action["c"][0])
         m = float(state["a"][0]) * d2_calibration["R"] + d2_calibration["y"]
-        assert 0.0 <= c <= m  # respects D-2 borrowing constraint
+        ub = d2_block.dynamics["c"].upper_bound(m)  # m + H, natural borrowing limit
+        assert 0.0 <= c <= ub  # respects D-2 natural borrowing limit
 
 
 def test_snapshot_decision_rule_rejects_wrong_iset_arity(d2_agent):


### PR DESCRIPTION
d2_block and d3_block imposed c <= m (equivalently a' >= 0), a no-borrowing constraint that contradicts their unconstrained perfect-foresight closed-form policies c = kappa*(m + H), which borrow against human wealth H = y/(R-1). A solver on the block therefore disagreed with the analytical oracle by ~6-10%. Relax the block upper bound to the natural borrowing limit c <= m + H, with H derived from each calibration as a module-level constant.

Supporting changes:
- GymEnv._bounds_at treats a single-point feasible set (lo == hi, reached at the natural limit m = -H) as valid, raising only on a genuinely inverted bound (hi < lo).
- Update the test_sb3 assertions that hard-coded c <= m to assert against the block's own upper_bound.
- Add tests/test_benchmark_bound_consistency.py: a regression test asserting the analytical policy is feasible under the block's own bounds on states that reach the borrowing region (a' < 0); it fails against the old c <= m bound.



## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] CHANGELOG.md updated (under `[Unreleased]` section)
- [ ] Breaking changes noted in CHANGELOG if applicable
